### PR TITLE
Add initial CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: Continuous Integration
+
+on:
+  push:
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Build
+        run: cargo build --verbose
+      - name: Test
+        run: cargo test --verbose


### PR DESCRIPTION
This will trigger on all pushes and all pull requests and run `cargo build` and `cargo test`, following the documentation at https://doc.rust-lang.org/cargo/guide/continuous-integration.html