### PR TITLE
Migrate from crc32c to crc-any dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,12 +27,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "crc32c"
-version = "0.6.8"
+name = "crc-any"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+checksum = "a62ec9ff5f7965e4d7280bd5482acd20aadb50d632cf6c1d74493856b011fa73"
 dependencies = [
- "rustc_version",
+ "debug-helper",
 ]
 
 [[package]]
@@ -40,12 +40,18 @@ name = "dcsctp"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "crc32c",
+ "crc-any",
  "itertools",
  "log",
  "rand",
  "thiserror",
 ]
+
+[[package]]
+name = "debug-helper"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f578e8e2c440e7297e008bb5486a3a8a194775224bbc23729b0dbdfaeebf162e"
 
 [[package]]
 name = "either"
@@ -147,21 +153,6 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom",
 ]
-
-[[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
-name = "semver"
-version = "1.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["network-programming"]
 
 [dependencies]
 anyhow = "1.0.98"
-crc32c = "0.6.8"
+crc-any = "2.5.0"
 log = "0.4.27"
 rand = "0.9.1"
 thiserror = "2.0.12"


### PR DESCRIPTION
This is already used by other projects, so to avoid importing yet another crate that creates checksums, use this one.

There are a few unit tests that parses captured packets from wireshark, so those will validate that the library is used correctly.