### PR TITLE
Add pull mode for messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## Unreleased
 
+### Changed
+
+- A pull-based API for receiving messages, which allows for back-pressure to be
+  applied when the application can't consume messages fast enough.
+
 ## 0.1.0 - 2025-08-12
 
 First release.

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -428,10 +428,6 @@ pub enum SocketEvent {
     /// Generated when the library wants a datagram packet to be sent.
     SendPacket(Vec<u8>),
 
-    /// Generated when the library has received an SCTP message in full and delivers it to the
-    /// upper layer.
-    OnMessage(Message),
-
     /// Generated when calling [`DcSctpSocket::connect`] succeeds, but also for incoming successful
     /// connection attempts.
     OnConnected(),
@@ -655,6 +651,16 @@ pub trait DcSctpSocket {
     /// Returns the next generated event, if any.
     fn poll_event(&mut self) -> Option<SocketEvent>;
 
+    /// Retrieves the next received message from the incoming message queue.
+    ///
+    /// When the socket receives data from the peer, it reassembles it into messages. Once a
+    /// message is fully reassembled, it's placed in a queue. This method retrieves the
+    /// first message from that queue.
+    ///
+    /// Returns `Some(Message)` if there is a message available, and `None` otherwise.
+    /// It's recommended to check [`DcSctpSocket::messages_ready_count`] before calling this.
+    fn get_next_message(&mut self) -> Option<Message>;
+
     /// To be called when an incoming SCTP packet is to be processed.
     fn handle_input(&mut self, packet: &[u8]);
 
@@ -696,6 +702,10 @@ pub trait DcSctpSocket {
 
     /// The socket state.
     fn state(&self) -> SocketState;
+
+    /// Returns the number of fully reassembled messages waiting in the incoming message queue.
+    /// These messages can be retrieved by calling [`DcSctpSocket::get_next_message`].
+    fn messages_ready_count(&self) -> usize;
 
     fn options(&self) -> Options;
 

--- a/src/socket/transmission_control_block.rs
+++ b/src/socket/transmission_control_block.rs
@@ -116,7 +116,6 @@ impl TransmissionControlBlock {
             reassembly_queue: ReassemblyQueue::new(
                 options.max_receiver_window_buffer_size,
                 capabilities.message_interleaving,
-                Rc::clone(&events),
             ),
             retransmission_queue: RetransmissionQueue::new(
                 Rc::clone(&events),

--- a/src/testing/event_helpers.rs
+++ b/src/testing/event_helpers.rs
@@ -47,12 +47,6 @@ macro_rules! expect_sent_packet {
     };
 }
 
-macro_rules! expect_on_message {
-    ($event:expr) => {
-        crate::expect_event_1!($event, OnMessage)
-    };
-}
-
 macro_rules! expect_on_connected {
     ($event:expr) => {
         crate::expect_event_0!($event, OnConnected)
@@ -194,7 +188,6 @@ pub(crate) use expect_on_lifecycle_message_expired;
 pub(crate) use expect_on_lifecycle_message_fully_sent;
 #[allow(unused_imports)]
 pub(crate) use expect_on_lifecycle_message_maybe_sent;
-pub(crate) use expect_on_message;
 pub(crate) use expect_on_streams_reset_performed;
 pub(crate) use expect_sent_packet;
 pub(crate) use expect_total_buffered_amount_low;


### PR DESCRIPTION
This brings the API from
https://webrtc-review.googlesource.com/c/src/+/383780 to this implementation and replaces the previous event based method of delivering messages.

Before this commit, when messages were fully reassembled, they were removed from the reassembly queue and put in the event queue, waiting for the upper layer application to eventually process the events and the received messages.

If the upper layer application couldn't do that in the same pace as messages were received on the network, e.g. if it is running in a different lower priority thread than the SCTP socket, this could result in unbounded memory usage. And there was no signal to the sender to stop sending (back-pressure) as from the socket's point of view, there were no messages in the buffers and it would then keep the advertised receiver window large.

By buffering messages in the socket until they are pulled/consumed from the upper layer application, the socket will correctly account for the memory used by the received (but not consumed) messages, and will signal the sending client to back off, by having a low advertised receiver window.

As this implementation doesn't have to maintain backwards compatibility, this will be the only supported way, and the old event based method has been removed.