### PR TITLE
Expose the Socket class in the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## Unreleased
 
+### Added
+
+- Exposed Socket in the public API.
+
 ### Changed
 
 - A pull-based API for receiving messages, which allows for back-pressure to be

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -21,6 +21,8 @@ use std::time::Instant;
 
 pub mod handover;
 
+pub use crate::socket::Socket;
+
 /// An identifier that can be set on sent messages, and picked by the sending client. If set,
 /// lifecycle events will be generated, and eventually [`SocketEvent::OnLifecycleEnd`] will be
 /// generated to indicate that the lifecycle isn't tracked any longer. The value zero (0) is not a

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -287,6 +287,12 @@ macro_rules! transition_between {
   };
 }
 
+/// An SCTP socket.
+///
+/// The socket is the main entry point for using the `dcsctp` library. It is used to send and
+/// receive messages, and to manage the connection.
+///
+/// To create a socket, use the [`Socket::new`] method.
 pub struct Socket<'a> {
     name: String,
     start_time: Instant,
@@ -413,6 +419,10 @@ fn compute_capabilities(
 }
 
 impl Socket<'_> {
+    /// Creates a new `Socket`.
+    ///
+    /// The provided `name` is only used for logging to identify this socket, and `start_time`
+    /// is the initial time, used as a basline for all time-based operations.
     pub fn new(name: &str, start_time: Instant, options: &Options) -> Self {
         let now = Rc::new(RefCell::new(start_time));
         let events: Rc<RefCell<Events>> = Rc::new(RefCell::new(Events::new()));


### PR DESCRIPTION
This exposes the main implementation of the `DcSctpSocket` trait, which clients will instantiate.