### PR TITLE
Estimate rwnd by payload bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## Unreleased
 
+### Fixed
+
+ - Align sender and receiver to signal advertised receiver window size as
+   payload bytes, excluding any headers.
+
 ## 0.1.11 - 2026-04-08
 
 ### Fixed

--- a/src/socket/shutdown.rs
+++ b/src/socket/shutdown.rs
@@ -262,7 +262,7 @@ pub(crate) fn maybe_send_shutdown_on_packet_received(
 
 pub(crate) fn maybe_send_shutdown(state: &mut State, ctx: &mut Context, now: SocketTime) {
     let State::ShutdownPending(tcb) = state else { unreachable!() };
-    if tcb.retransmission_queue.unacked_bytes() != 0 {
+    if tcb.retransmission_queue.unacked_items() != 0 {
         // Not ready to shutdown yet.
         return;
     }
@@ -292,7 +292,7 @@ pub(crate) fn maybe_send_shutdown(state: &mut State, ctx: &mut Context, now: Soc
 
 pub(crate) fn maybe_send_shutdown_ack(state: &mut State, ctx: &mut Context, now: SocketTime) {
     let State::ShutdownReceived(tcb) = state else { unreachable!() };
-    if tcb.retransmission_queue.unacked_bytes() != 0 {
+    if tcb.retransmission_queue.unacked_items() != 0 {
         // Not ready to shutdown yet.
         return;
     }

--- a/src/tx/outstanding_data.rs
+++ b/src/tx/outstanding_data.rs
@@ -84,8 +84,13 @@ enum NackAction {
 /// Contains variables scoped to a processing of an incoming SACK.
 #[derive(Debug)]
 pub(crate) struct AckInfo {
-    /// Bytes acked by increasing cumulative_tsn_ack and gap_ack_blocks.
-    pub bytes_acked: usize,
+    /// Bytes acked by increasing cumulative_tsn_ack and gap_ack_blocks, including DATA headers and
+    /// padding.
+    pub packet_bytes_acked: usize,
+
+    /// Payload bytes (excluding headers) acked by increasing cumulative_tsn_ack and
+    /// gap_ack_blocks.
+    pub payload_bytes_acked: usize,
 
     /// Indicates if this SACK indicates that packet loss has occurred. Just because a packet is
     /// missing in the SACK doesn't necessarily mean that there is packet loss as that packet might
@@ -257,7 +262,10 @@ pub(crate) struct OutstandingData {
     data_chunk_header_size: usize,
     last_cumulative_tsn_ack: Tsn,
     outstanding_data: VecDeque<Item>,
-    unacked_bytes: usize,
+    // Only payload, no padding or DATA headers.
+    unacked_payload_bytes: usize,
+    // Payload, padding and DATA headers.
+    unacked_packet_bytes: usize,
     unacked_items: usize,
     to_be_fast_retransmitted: BTreeSet<Tsn>,
     to_be_retransmitted: BTreeSet<Tsn>,
@@ -271,7 +279,8 @@ impl OutstandingData {
             data_chunk_header_size,
             last_cumulative_tsn_ack,
             outstanding_data: VecDeque::new(),
-            unacked_bytes: 0,
+            unacked_payload_bytes: 0,
+            unacked_packet_bytes: 0,
             unacked_items: 0,
             to_be_fast_retransmitted: BTreeSet::new(),
             to_be_retransmitted: BTreeSet::new(),
@@ -291,7 +300,8 @@ impl OutstandingData {
 
         let mut ack_info = AckInfo {
             highest_tsn_acked: cumulative_tsn_ack,
-            bytes_acked: 0,
+            packet_bytes_acked: 0,
+            payload_bytes_acked: 0,
             has_packet_loss: false,
             acked_lifecycle_ids: vec![],
             abandoned_lifecycle_ids: vec![],
@@ -419,7 +429,8 @@ impl OutstandingData {
         let action = item.nack(retransmit_now);
 
         if was_outstanding && !item.is_outstanding() {
-            self.unacked_bytes -=
+            self.unacked_payload_bytes -= item.data.payload.len();
+            self.unacked_packet_bytes -=
                 round_up_to_4!(self.data_chunk_header_size + item.data.payload.len());
             self.unacked_items -= 1;
         }
@@ -448,9 +459,11 @@ impl OutstandingData {
         if !item.is_acked() {
             let serialized_size =
                 round_up_to_4!(self.data_chunk_header_size + item.data.payload.len());
-            ack_info.bytes_acked += serialized_size;
+            ack_info.packet_bytes_acked += serialized_size;
+            ack_info.payload_bytes_acked += item.data.payload.len();
             if item.is_outstanding() {
-                self.unacked_bytes -= serialized_size;
+                self.unacked_payload_bytes -= item.data.payload.len();
+                self.unacked_packet_bytes -= serialized_size;
                 self.unacked_items -= 1;
             }
             if item.should_be_retransmitted() {
@@ -491,7 +504,8 @@ impl OutstandingData {
                 item.mark_as_retransmitted(now);
                 result.push((*tsn, item.data.clone()));
                 max_size -= size;
-                self.unacked_bytes += size;
+                self.unacked_payload_bytes += item.data.payload.len();
+                self.unacked_packet_bytes += size;
                 self.unacked_items += 1;
             }
             if max_size <= self.data_chunk_header_size {
@@ -539,8 +553,12 @@ impl OutstandingData {
         chunks
     }
 
-    pub fn unacked_bytes(&self) -> usize {
-        self.unacked_bytes
+    pub fn unacked_payload_bytes(&self) -> usize {
+        self.unacked_payload_bytes
+    }
+
+    pub fn unacked_packet_bytes(&self) -> usize {
+        self.unacked_packet_bytes
     }
 
     /// Returns the number of DATA chunks that are in-flight (not acked or nacked).
@@ -619,9 +637,10 @@ impl OutstandingData {
         // isn't a fragment of an already discarded message.
         debug_assert!(self.unsent_messages_to_discard.is_empty());
 
+        self.unacked_payload_bytes += data.payload.len();
         // All chunks are always padded to be even divisible by 4.
         let chunk_size = round_up_to_4!(self.data_chunk_header_size + data.payload.len());
-        self.unacked_bytes += chunk_size;
+        self.unacked_packet_bytes += chunk_size;
         self.unacked_items += 1;
         let tsn = self.next_tsn();
         let item = Item {
@@ -673,7 +692,8 @@ impl OutstandingData {
                     }
                     other.abandon();
                     if was_outstanding {
-                        self.unacked_bytes -=
+                        self.unacked_payload_bytes -= other.data.payload.len();
+                        self.unacked_packet_bytes -=
                             round_up_to_4!(self.data_chunk_header_size + other.data.payload.len());
                         self.unacked_items -= 1;
                     }
@@ -910,7 +930,8 @@ mod tests {
         let buf = OutstandingData::new(DATA_CHUNK_HEADER_SIZE, Tsn(9));
 
         assert!(buf.is_empty());
-        assert_eq!(buf.unacked_bytes(), 0);
+        assert_eq!(buf.unacked_payload_bytes(), 0);
+        assert_eq!(buf.unacked_packet_bytes(), 0);
         assert_eq!(buf.unacked_items(), 0);
         assert!(!buf.has_data_to_be_retransmitted());
         assert_eq!(buf.last_cumulative_acked_tsn(), Tsn(9));
@@ -926,7 +947,8 @@ mod tests {
         let mut seq = DataSequencer::new(StreamId(1));
         let tsn = insert(&mut buf, seq.ordered("a", "BE"));
         assert_eq!(tsn, Tsn(10));
-        assert_eq!(buf.unacked_bytes(), DATA_CHUNK_HEADER_SIZE + round_up_to_4!(1));
+        assert_eq!(buf.unacked_payload_bytes(), 1);
+        assert_eq!(buf.unacked_packet_bytes(), DATA_CHUNK_HEADER_SIZE + round_up_to_4!(1));
         assert_eq!(buf.unacked_items(), 1);
         assert!(!buf.has_data_to_be_retransmitted());
         assert_eq!(buf.last_cumulative_acked_tsn(), Tsn(9));
@@ -946,11 +968,13 @@ mod tests {
         assert_eq!(tsn, Tsn(10));
         let ack = buf.handle_sack(Tsn(10), &[], false);
 
-        assert_eq!(ack.bytes_acked, DATA_CHUNK_HEADER_SIZE + round_up_to_4!(1));
+        assert_eq!(ack.payload_bytes_acked, 1);
+        assert_eq!(ack.packet_bytes_acked, DATA_CHUNK_HEADER_SIZE + round_up_to_4!(1));
         assert_eq!(ack.highest_tsn_acked, Tsn(10));
         assert!(!ack.has_packet_loss);
 
-        assert_eq!(buf.unacked_bytes(), 0);
+        assert_eq!(buf.unacked_payload_bytes(), 0);
+        assert_eq!(buf.unacked_packet_bytes(), 0);
         assert_eq!(buf.unacked_items(), 0);
         assert!(!buf.has_data_to_be_retransmitted());
         assert_eq!(buf.last_cumulative_acked_tsn(), Tsn(10));
@@ -967,11 +991,13 @@ mod tests {
         assert_eq!(tsn, Tsn(10));
         let ack = buf.handle_sack(Tsn(9), &[], false);
 
-        assert_eq!(ack.bytes_acked, 0);
+        assert_eq!(ack.payload_bytes_acked, 0);
+        assert_eq!(ack.packet_bytes_acked, 0);
         assert_eq!(ack.highest_tsn_acked, Tsn(9));
         assert!(!ack.has_packet_loss);
 
-        assert_eq!(buf.unacked_bytes(), DATA_CHUNK_HEADER_SIZE + round_up_to_4!(1));
+        assert_eq!(buf.unacked_payload_bytes(), 1);
+        assert_eq!(buf.unacked_packet_bytes(), DATA_CHUNK_HEADER_SIZE + round_up_to_4!(1));
         assert_eq!(buf.unacked_items(), 1);
         assert!(!buf.has_data_to_be_retransmitted());
         assert_eq!(buf.last_cumulative_acked_tsn(), Tsn(9));
@@ -992,11 +1018,13 @@ mod tests {
 
         let ack = buf.handle_sack(Tsn(9), &[GapAckBlock::new(2, 2)], false);
 
-        assert_eq!(ack.bytes_acked, DATA_CHUNK_HEADER_SIZE + round_up_to_4!(1));
+        assert_eq!(ack.payload_bytes_acked, 1);
+        assert_eq!(ack.packet_bytes_acked, DATA_CHUNK_HEADER_SIZE + round_up_to_4!(1));
         assert_eq!(ack.highest_tsn_acked, Tsn(11));
         assert!(!ack.has_packet_loss);
 
-        assert_eq!(buf.unacked_bytes(), DATA_CHUNK_HEADER_SIZE + round_up_to_4!(1));
+        assert_eq!(buf.unacked_payload_bytes(), 1);
+        assert_eq!(buf.unacked_packet_bytes(), DATA_CHUNK_HEADER_SIZE + round_up_to_4!(1));
         assert_eq!(buf.unacked_items(), 1);
         assert!(!buf.has_data_to_be_retransmitted());
         assert_eq!(buf.last_cumulative_acked_tsn(), Tsn(9));
@@ -1048,7 +1076,8 @@ mod tests {
         assert!(!buf.has_data_to_be_retransmitted());
 
         let ack = buf.handle_sack(Tsn(9), &[GapAckBlock::new(2, 4)], false);
-        assert_eq!(ack.bytes_acked, DATA_CHUNK_HEADER_SIZE + round_up_to_4!(1));
+        assert_eq!(ack.payload_bytes_acked, 1);
+        assert_eq!(ack.packet_bytes_acked, DATA_CHUNK_HEADER_SIZE + round_up_to_4!(1));
         assert_eq!(ack.highest_tsn_acked, Tsn(13));
         assert!(ack.has_packet_loss);
 
@@ -1080,7 +1109,8 @@ mod tests {
         assert!(!buf.has_data_to_be_retransmitted());
 
         let ack = buf.handle_sack(Tsn(9), &[GapAckBlock::new(2, 4)], false);
-        assert_eq!(ack.bytes_acked, DATA_CHUNK_HEADER_SIZE + round_up_to_4!(1));
+        assert_eq!(ack.payload_bytes_acked, 1);
+        assert_eq!(ack.packet_bytes_acked, DATA_CHUNK_HEADER_SIZE + round_up_to_4!(1));
         assert_eq!(ack.highest_tsn_acked, Tsn(13));
         assert!(ack.has_packet_loss);
 
@@ -1129,7 +1159,8 @@ mod tests {
         assert!(!buf.has_data_to_be_retransmitted());
         assert!(!buf.has_unsent_messages_to_discard());
         let ack = buf.handle_sack(Tsn(9), &[GapAckBlock::new(2, 4)], false);
-        assert_eq!(ack.bytes_acked, DATA_CHUNK_HEADER_SIZE + round_up_to_4!(1));
+        assert_eq!(ack.payload_bytes_acked, 1);
+        assert_eq!(ack.packet_bytes_acked, DATA_CHUNK_HEADER_SIZE + round_up_to_4!(1));
         assert_eq!(ack.highest_tsn_acked, Tsn(13));
         assert!(ack.has_packet_loss);
 
@@ -1831,7 +1862,8 @@ mod tests {
         // Ack TSN=9,11,13 - 11 and 13 are newly acked, reflected in bytes_acked.
         let ack1 =
             buf.handle_sack(Tsn(9), &[GapAckBlock::new(2, 2), GapAckBlock::new(4, 4)], false);
-        assert_eq!(ack1.bytes_acked, chunk_size * 2);
+        assert_eq!(ack1.payload_bytes_acked, 2);
+        assert_eq!(ack1.packet_bytes_acked, chunk_size * 2);
 
         // Advance time to expire the first message.
         buf.expire_outstanding_chunks(now + Duration::from_millis(200));
@@ -1851,7 +1883,8 @@ mod tests {
         let ack2 = buf.handle_sack(Tsn(13), &[], false);
 
         // Only TSN 10 and 12 should be counted as "newly acked" bytes.
-        assert_eq!(ack2.bytes_acked, chunk_size * 2);
+        assert_eq!(ack2.payload_bytes_acked, 2);
+        assert_eq!(ack2.packet_bytes_acked, chunk_size * 2);
     }
 
     #[test]
@@ -1878,8 +1911,9 @@ mod tests {
         let ack = buf.handle_sack(Tsn(11), &[], false);
 
         // Only the actual data (TSN 10) should contribute to bytes_acked, not TSN=11.
-        let expected_size = round_up_to_4!(DATA_CHUNK_HEADER_SIZE + 1);
-        assert_eq!(ack.bytes_acked, expected_size);
+        assert_eq!(ack.payload_bytes_acked, 1);
+        let expected_size = round_up_to_4!(DATA_CHUNK_HEADER_SIZE + round_up_to_4!(1));
+        assert_eq!(ack.packet_bytes_acked, expected_size);
     }
 
     #[test]

--- a/src/tx/retransmission_queue.rs
+++ b/src/tx/retransmission_queue.rs
@@ -140,7 +140,7 @@ impl RetransmissionQueue {
     }
 
     fn start_t3_rtx_if_outstanding_data(&mut self, now: SocketTime) {
-        // Note: Can't use `unacked_bytes` as that one doesn't count chunks to be retransmitted.
+        // Note: Can't use `unacked_items` as that one doesn't count chunks to be retransmitted.
         if self.outstanding_data.is_empty() {
             // From <https://datatracker.ietf.org/doc/html/rfc9260#section-6.3.2-2.2.1>:
             //
@@ -204,12 +204,12 @@ impl RetransmissionQueue {
 
     fn handle_increased_cumulative_tsn_ack(
         &mut self,
-        unacked_bytes: usize,
-        total_bytes_acked: usize,
+        unacked_packet_bytes: usize,
+        total_packet_bytes_acked: usize,
     ) {
         // Allow some margin for classifying as fully utilized, due to e.g. that too small packets
         // are not sent + overhead.
-        let is_fully_utilized = unacked_bytes + self.mtu >= self.cwnd;
+        let is_fully_utilized = unacked_packet_bytes + self.mtu >= self.cwnd;
         let old_cwnd = self.cwnd;
 
         // TODO: Make the implementation compliant with RFC 9260.
@@ -229,7 +229,7 @@ impl RetransmissionQueue {
                     //      and
                     //
                     //   2. L times the destination's PMDCS.
-                    self.cwnd += min(total_bytes_acked, self.mtu);
+                    self.cwnd += min(total_packet_bytes_acked, self.mtu);
                     log::debug!("SS increase cwnd={} ({})", self.cwnd, old_cwnd);
                 }
             }
@@ -242,7 +242,7 @@ impl RetransmissionQueue {
                 //   including chunks acknowledged by the new Cumulative TSN Ack, by Gap Ack Blocks,
                 //   and by the number of bytes of duplicated chunks reported in Duplicate TSNs.
                 let old_pba = self.partial_bytes_acked;
-                self.partial_bytes_acked += total_bytes_acked;
+                self.partial_bytes_acked += total_packet_bytes_acked;
                 if self.partial_bytes_acked >= self.cwnd && is_fully_utilized {
                     // From <https://datatracker.ietf.org/doc/html/rfc9260#section-7.2.2>:
                     //
@@ -330,7 +330,8 @@ impl RetransmissionQueue {
         }
 
         let old_last_cumulative_tsn_ack = self.outstanding_data.last_cumulative_acked_tsn();
-        let old_unacked_bytes = self.outstanding_data.unacked_bytes();
+        let old_unacked_packet_bytes = self.outstanding_data.unacked_packet_bytes();
+        let old_unacked_payload_bytes = self.outstanding_data.unacked_payload_bytes();
         let old_rwnd = self.rwnd();
 
         let rtt = if sack.gap_ack_blocks.is_empty() {
@@ -363,11 +364,11 @@ impl RetransmissionQueue {
         self.a_rwnd = sack.a_rwnd as usize;
 
         log::debug!(
-            "Received SACK, cum_tsn_ack={} ({}), unacked_bytes={} ({}), rwnd={} ({})",
+            "Received SACK, cum_tsn_ack={} ({}), unacked_payload_bytes={} ({}), rwnd={} ({})",
             sack.cumulative_tsn_ack,
             old_last_cumulative_tsn_ack,
-            self.outstanding_data.unacked_bytes(),
-            old_unacked_bytes,
+            self.outstanding_data.unacked_payload_bytes(),
+            old_unacked_payload_bytes,
             self.rwnd(),
             old_rwnd
         );
@@ -382,7 +383,10 @@ impl RetransmissionQueue {
             // Note: It may be started again in a bit further down.
             self.t3_rtx.stop();
 
-            self.handle_increased_cumulative_tsn_ack(old_unacked_bytes, ack_info.bytes_acked);
+            self.handle_increased_cumulative_tsn_ack(
+                old_unacked_packet_bytes,
+                ack_info.packet_bytes_acked,
+            );
         }
 
         if ack_info.has_packet_loss {
@@ -393,7 +397,7 @@ impl RetransmissionQueue {
         //
         //   When an outstanding TSN is acknowledged [...] the endpoint SHOULD clear the error
         //   counter [...].
-        let reset_error_counter = ack_info.bytes_acked > 0;
+        let reset_error_counter = ack_info.payload_bytes_acked > 0;
 
         self.start_t3_rtx_if_outstanding_data(now);
 
@@ -411,7 +415,7 @@ impl RetransmissionQueue {
         }
 
         let old_cwnd = self.cwnd;
-        let old_unacked_bytes = self.unacked_bytes();
+        let old_unacked_packet_bytes = self.unacked_packet_bytes();
 
         // From <https://datatracker.ietf.org/doc/html/rfc9260#section-6.3.3>:
         //
@@ -448,12 +452,12 @@ impl RetransmissionQueue {
         // This is already done by the timer implementation.
 
         log::debug!(
-            "t3-rtx expired. new cwnd={} ({}), ssthresh={}, unacked_bytes {} ({})",
+            "t3-rtx expired. new cwnd={} ({}), ssthresh={}, unacked_packet_bytes {} ({})",
             self.cwnd,
             old_cwnd,
             self.ssthresh,
-            self.unacked_bytes(),
-            old_unacked_bytes
+            self.unacked_packet_bytes(),
+            old_unacked_packet_bytes
         );
         true
     }
@@ -471,7 +475,7 @@ impl RetransmissionQueue {
     ) -> Vec<(Tsn, Data)> {
         debug_assert!(is_divisible_by_4!(bytes_remaining_in_packet));
 
-        let old_unacked_bytes = self.unacked_bytes();
+        let old_unacked_packet_bytes = self.unacked_packet_bytes();
 
         let to_be_sent = self
             .outstanding_data
@@ -495,20 +499,20 @@ impl RetransmissionQueue {
             self.t3_rtx.start(now);
         }
 
-        let bytes_retransmitted: usize = to_be_sent
+        let packet_bytes_retransmitted: usize = to_be_sent
             .iter()
             .map(|(_, data)| round_up_to_4!(self.data_chunk_header_size + data.payload.len()))
             .sum();
 
         self.rtx_packets_count += 1;
-        self.rtx_bytes_count += bytes_retransmitted as u64;
+        self.rtx_bytes_count += packet_bytes_retransmitted as u64;
 
         log::debug!(
-            "Fast-retransmitting TSN {} - {} bytes. unacked_bytes={} ({})",
+            "Fast-retransmitting TSN {} - {} bytes. unacked_packet_bytes={} ({})",
             to_be_sent.iter().map(|(tsn, _)| tsn.to_string()).collect::<Vec<_>>().join(","),
-            bytes_retransmitted,
-            self.unacked_bytes(),
-            old_unacked_bytes
+            packet_bytes_retransmitted,
+            self.unacked_packet_bytes(),
+            old_unacked_packet_bytes
         );
 
         to_be_sent
@@ -538,21 +542,21 @@ impl RetransmissionQueue {
     ) -> Vec<(Tsn, Data)> {
         debug_assert!(is_divisible_by_4!(bytes_remaining_in_packet));
 
-        let old_unacked_bytes = self.unacked_bytes();
+        let old_unacked_packet_bytes = self.unacked_packet_bytes();
         let old_rwnd = self.rwnd();
 
         let mut max_bytes =
             round_down_to_4!(min(self.max_bytes_to_send(), bytes_remaining_in_packet));
         let mut to_be_sent = self.outstanding_data.get_chunks_to_be_retransmitted(now, max_bytes);
-        let bytes_retransmitted: usize = to_be_sent
+        let packet_bytes_retransmitted: usize = to_be_sent
             .iter()
             .map(|(_, data)| round_up_to_4!(self.data_chunk_header_size + data.payload.len()))
             .sum();
-        max_bytes -= bytes_retransmitted;
+        max_bytes -= packet_bytes_retransmitted;
 
         if !to_be_sent.is_empty() {
             self.rtx_packets_count += 1;
-            self.rtx_bytes_count += bytes_retransmitted as u64;
+            self.rtx_bytes_count += packet_bytes_retransmitted as u64;
         }
 
         while max_bytes > self.data_chunk_header_size {
@@ -595,11 +599,11 @@ impl RetransmissionQueue {
                 .map(|(_, data)| round_up_to_4!(self.data_chunk_header_size + data.payload.len()))
                 .sum();
             log::debug!(
-                "Sending TSN {} - {} bytes. unacked_bytes={} ({}),  cwnd={}, rwnd={} ({})",
+                "Sending TSN {} - {} bytes. unacked_packet_bytes={} ({}),  cwnd={}, rwnd={} ({})",
                 to_be_sent.iter().map(|(tsn, _)| tsn.to_string()).collect::<Vec<_>>().join(","),
                 sent_bytes,
-                self.unacked_bytes(),
-                old_unacked_bytes,
+                self.unacked_packet_bytes(),
+                old_unacked_packet_bytes,
                 self.cwnd,
                 self.rwnd(),
                 old_rwnd
@@ -648,7 +652,7 @@ impl RetransmissionQueue {
 
     /// Returns the current receiver window size.
     pub fn rwnd(&self) -> usize {
-        self.a_rwnd.saturating_sub(self.outstanding_data.unacked_bytes())
+        self.a_rwnd.saturating_sub(self.outstanding_data.unacked_payload_bytes())
     }
 
     pub fn rtx_packets_count(&self) -> usize {
@@ -659,9 +663,9 @@ impl RetransmissionQueue {
         self.rtx_bytes_count
     }
 
-    /// Returns the number of bytes of packets that are in-flight.
-    pub fn unacked_bytes(&self) -> usize {
-        self.outstanding_data.unacked_bytes()
+    /// Returns the number of bytes (payload and headers) that are in-flight.
+    pub fn unacked_packet_bytes(&self) -> usize {
+        self.outstanding_data.unacked_packet_bytes()
     }
 
     /// Returns the number of DATA chunks that are in-flight.
@@ -672,8 +676,8 @@ impl RetransmissionQueue {
     /// Returns the number of bytes that may be sent in a single packet according to the congestion
     /// control algorithm.
     fn max_bytes_to_send(&self) -> usize {
-        let left = self.cwnd.saturating_sub(self.unacked_bytes());
-        if self.unacked_bytes() == 0 {
+        let left = self.cwnd.saturating_sub(self.unacked_packet_bytes());
+        if self.unacked_items() == 0 {
             // TODO: Make the implementation compliant with RFC 9260.
             //
             // From <https://datatracker.ietf.org/doc/html/rfc9260#section-6.1>:
@@ -1382,7 +1386,7 @@ mod tests {
 
         rtx.set_cwnd(CWND);
         assert_eq!(rtx.cwnd(), CWND);
-        assert_eq!(rtx.unacked_bytes(), 0);
+        assert_eq!(rtx.unacked_packet_bytes(), 0);
         assert_eq!(rtx.unacked_items(), 0);
 
         sq.add(
@@ -1399,7 +1403,7 @@ mod tests {
             rtx.get_chunk_states_for_testing(),
             [(Tsn(9), ChunkState::Acked), (Tsn(10), ChunkState::InFlight),]
         );
-        assert_eq!(rtx.unacked_bytes(), 1000 + data_chunk::HEADER_SIZE);
+        assert_eq!(rtx.unacked_packet_bytes(), 1000 + data_chunk::HEADER_SIZE);
         assert_eq!(rtx.unacked_items(), 1);
 
         // Will force chunks to be retransmitted
@@ -1410,13 +1414,13 @@ mod tests {
             rtx.get_chunk_states_for_testing(),
             [(Tsn(9), ChunkState::Acked), (Tsn(10), ChunkState::ToBeRetransmitted),]
         );
-        assert_eq!(rtx.unacked_bytes(), 0);
+        assert_eq!(rtx.unacked_packet_bytes(), 0);
         assert_eq!(rtx.unacked_items(), 0);
         assert_eq!(
             get_tsns(&rtx.get_chunks_to_send(now, 1500, |bytes, _| sq.produce(now, bytes))),
             [Tsn(10)]
         );
-        assert_eq!(rtx.unacked_bytes(), 1000 + data_chunk::HEADER_SIZE);
+        assert_eq!(rtx.unacked_packet_bytes(), 1000 + data_chunk::HEADER_SIZE);
         assert_eq!(rtx.unacked_items(), 1);
     }
 
@@ -1898,8 +1902,8 @@ mod tests {
 
     #[test]
     fn accounts_nacked_abandoned_chunks_as_not_outstanding() {
-        // Verifies that unacked_bytes/unacked_items are set correctly for abandoned items, and when
-        // acking them.
+        // Verifies that unacked_packet_bytes/unacked_items are set correctly for abandoned items,
+        // and when acking them.
         let mut now = START_TIME;
         let events = Rc::new(RefCell::new(Events::new()));
         let events_clone = Rc::clone(&events) as Rc<RefCell<dyn EventSink>>;
@@ -1941,7 +1945,7 @@ mod tests {
                 (Tsn(12), ChunkState::InFlight),
             ]
         );
-        assert_eq!(rtx.unacked_bytes(), (data_chunk::HEADER_SIZE + 4) * 3);
+        assert_eq!(rtx.unacked_packet_bytes(), (data_chunk::HEADER_SIZE + 4) * 3);
         assert_eq!(rtx.unacked_items(), 3);
 
         // Will force chunks to be retransmitted
@@ -1957,7 +1961,7 @@ mod tests {
                 (Tsn(13), ChunkState::Abandoned),
             ]
         );
-        assert_eq!(rtx.unacked_bytes(), 0);
+        assert_eq!(rtx.unacked_packet_bytes(), 0);
         assert_eq!(rtx.unacked_items(), 0);
 
         assert_eq!(
@@ -1973,19 +1977,19 @@ mod tests {
 
         // Now ACK those, one at a time.
         handle_sack(&mut rtx, now, Tsn(10));
-        assert_eq!(rtx.unacked_bytes(), 0);
+        assert_eq!(rtx.unacked_packet_bytes(), 0);
         assert_eq!(rtx.unacked_items(), 0);
 
         handle_sack(&mut rtx, now, Tsn(11));
-        assert_eq!(rtx.unacked_bytes(), 0);
+        assert_eq!(rtx.unacked_packet_bytes(), 0);
         assert_eq!(rtx.unacked_items(), 0);
 
         handle_sack(&mut rtx, now, Tsn(12));
-        assert_eq!(rtx.unacked_bytes(), 0);
+        assert_eq!(rtx.unacked_packet_bytes(), 0);
         assert_eq!(rtx.unacked_items(), 0);
 
         handle_sack(&mut rtx, now, Tsn(13));
-        assert_eq!(rtx.unacked_bytes(), 0);
+        assert_eq!(rtx.unacked_packet_bytes(), 0);
         assert_eq!(rtx.unacked_items(), 0);
     }
 
@@ -2363,7 +2367,7 @@ mod tests {
             get_tsns(&rtx.get_chunks_to_send(now, 1500, |bytes, _| sq.produce(now, bytes))),
             [Tsn(10)]
         );
-        assert_eq!(rtx.unacked_bytes(), 1000 + data_chunk::HEADER_SIZE);
+        assert_eq!(rtx.unacked_packet_bytes(), 1000 + data_chunk::HEADER_SIZE);
 
         handle_sack(&mut rtx, now, Tsn(10));
 


### PR DESCRIPTION
The dcSCTP receiver was advertising available window space (arwnd) based solely on payload bytes, while the sender's rwnd estimation included packet headers. This mismatch caused the sender to underestimate the receiver's available buffer, potentially leading to reduced throughput.

This commit resolves the issue by ensuring both sender and receiver use payload bytes, as headers have been removed on the receiver side while in the reassembly queue.

This is a Rust port of the fix to the upstream C++ implementation at https://webrtc-review.googlesource.com/c/src/+/377122.