### PR TITLE
Use bytes crate for zero-copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## Unreleased
 
+### Changed
+
+ - Byte payloads are now represented using the bytes crate.
+
 ## 0.1.12 - 2026-04-13
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
 name = "cc"
 version = "1.2.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,6 +145,7 @@ name = "dcsctp"
 version = "0.1.12"
 dependencies = [
  "arbitrary",
+ "bytes",
  "cxx",
  "cxx-build",
  "fastrand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 repository = "https://github.com/webrtc/dcsctp"
 
 [workspace.dependencies]
+bytes = "1.11"
 cxx = "1.0"
 cxx-build = "1.0"
 dcsctp = { path = "." }
@@ -49,6 +50,7 @@ license = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
+bytes = { workspace = true }
 cxx = { workspace = true, optional = true }
 fastrand = { workspace = true }
 log = { workspace = true }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -14,6 +14,7 @@
 
 use crate::api::handover::HandoverReadiness;
 use crate::api::handover::SocketHandoverState;
+use bytes::Bytes;
 use std::fmt;
 use std::num::NonZeroU64;
 use std::ops::Add;
@@ -175,12 +176,12 @@ pub struct Message {
     pub ppid: PpId,
 
     /// The payload of the message.
-    pub payload: Vec<u8>,
+    pub payload: Bytes,
 }
 
 impl Message {
     /// Creates a new `Message`.
-    pub fn new(stream_id: StreamId, ppid: PpId, payload: Vec<u8>) -> Self {
+    pub fn new(stream_id: StreamId, ppid: PpId, payload: Bytes) -> Self {
         Message { stream_id, ppid, payload }
     }
 }
@@ -490,7 +491,7 @@ impl Default for Options {
 #[derive(Debug)]
 pub enum SocketEvent {
     /// Generated when the library wants a datagram packet to be sent.
-    SendPacket(Vec<u8>),
+    SendPacket(Bytes),
 
     /// Generated when calling [`DcSctpSocket::connect`] succeeds, but also for incoming successful
     /// connection attempts.
@@ -737,7 +738,7 @@ pub trait DcSctpSocket {
     fn get_next_message(&mut self) -> Option<Message>;
 
     /// To be called when an incoming SCTP packet is to be processed.
-    fn handle_input(&mut self, packet: &[u8]);
+    fn handle_input(&mut self, packet: Bytes);
 
     /// Advances the internal clock to a specific point in the socket's lifetime.
     ///

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -38,6 +38,7 @@ use crate::api::handover::HandoverSocketState as DcSctpHandoverSocketState;
 use crate::api::handover::HandoverTransmission as DcSctpHandoverTransmission;
 use crate::api::handover::HandoverUnorderedStream as DcSctpHandoverUnorderedStream;
 use crate::api::handover::SocketHandoverState as DcSctpSocketHandoverState;
+use bytes::Bytes;
 use std::time::Duration;
 
 const MAX_LIFETIME_MS: u64 = 3600 * 1000;
@@ -551,7 +552,7 @@ impl From<DcSctpSocketEvent> for bridge::Event {
         match event {
             DcSctpSocketEvent::SendPacket(p) => bridge::Event {
                 event_type: bridge::EventType::SendPacket,
-                packet: p,
+                packet: p.to_vec(),
                 ..Default::default()
             },
             DcSctpSocketEvent::OnConnected() => {
@@ -932,7 +933,7 @@ fn set_buffered_amount_low_threshold(socket: &mut DcSctpSocket, stream_id: u16, 
 }
 
 fn handle_input(socket: &mut DcSctpSocket, data: &[u8]) {
-    socket.0.handle_input(data);
+    socket.0.handle_input(Bytes::copy_from_slice(data));
 }
 
 fn poll_event(socket: &mut DcSctpSocket) -> bridge::Event {
@@ -953,9 +954,11 @@ fn message_ready_count(socket: &DcSctpSocket) -> usize {
 
 fn get_next_message(socket: &mut DcSctpSocket) -> bridge::Message {
     match socket.0.get_next_message() {
-        Some(msg) => {
-            bridge::Message { stream_id: msg.stream_id.0, ppid: msg.ppid.0, payload: msg.payload }
-        }
+        Some(msg) => bridge::Message {
+            stream_id: msg.stream_id.0,
+            ppid: msg.ppid.0,
+            payload: msg.payload.to_vec(),
+        },
         None => bridge::Message::default(),
     }
 }
@@ -974,7 +977,8 @@ fn send(
     message: bridge::Message,
     options: &bridge::SendOptions,
 ) -> bridge::SendStatus {
-    let msg = DcSctpMessage::new(StreamId(message.stream_id), PpId(message.ppid), message.payload);
+    let msg =
+        DcSctpMessage::new(StreamId(message.stream_id), PpId(message.ppid), message.payload.into());
     socket.0.send(msg, &options.into()).into()
 }
 
@@ -986,7 +990,7 @@ fn send_many(
     let msg_len = messages.len();
     let messages: Vec<DcSctpMessage> = messages
         .into_iter()
-        .map(|msg| DcSctpMessage::new(StreamId(msg.stream_id), PpId(msg.ppid), msg.payload))
+        .map(|msg| DcSctpMessage::new(StreamId(msg.stream_id), PpId(msg.ppid), msg.payload.into()))
         .collect();
     let options: DcSctpSendOptions = options.into();
 

--- a/src/fuzzer/fuzz_outstanding_data.rs
+++ b/src/fuzzer/fuzz_outstanding_data.rs
@@ -25,6 +25,7 @@ use crate::types::StreamKey;
 use crate::types::Tsn;
 use arbitrary::Arbitrary;
 use arbitrary::Unstructured;
+use bytes::Bytes;
 use std::time::Duration;
 
 #[derive(Arbitrary, Debug)]
@@ -101,7 +102,7 @@ pub fn fuzz_outstanding_data(data: &[u8]) {
                     mid: Mid(mid),
                     is_beginning: true,
                     is_end: true,
-                    payload: vec![0; (payload_len % 1500) as usize + 1],
+                    payload: Bytes::from(vec![0; (payload_len % 1500) as usize + 1]),
                     ..Default::default()
                 };
 

--- a/src/fuzzer/mod.rs
+++ b/src/fuzzer/mod.rs
@@ -16,6 +16,7 @@ use crate::api::Options;
 use crate::packet::error_causes::error_cause_from_bytes;
 use crate::packet::parameter::parameters_from_bytes;
 use crate::packet::sctp_packet::SctpPacket;
+use bytes::Bytes;
 
 pub mod fuzz_outstanding_data;
 
@@ -29,5 +30,5 @@ pub fn parse_error_causes(data: &[u8]) {
 
 pub fn parse_packet(data: &[u8]) {
     let options = Options { disable_checksum_verification: true, ..Default::default() };
-    let _ = SctpPacket::from_bytes(data, &options);
+    let _ = SctpPacket::from_bytes(Bytes::copy_from_slice(data), &options);
 }

--- a/src/packet/abort_chunk.rs
+++ b/src/packet/abort_chunk.rs
@@ -75,6 +75,7 @@ impl fmt::Display for AbortChunk {
 mod tests {
     use super::*;
     use crate::packet::protocol_violation_error_cause::ProtocolViolationErrorCause;
+    use bytes::Bytes;
 
     #[test]
     fn init_from_capture() {
@@ -84,7 +85,8 @@ mod tests {
         //     Chunk length: 8
         //     User initiated ABORT cause
         const BYTES: &[u8] = &[0x06, 0x00, 0x00, 0x08, 0x00, 0x0c, 0x00, 0x04];
-        let abort = AbortChunk::try_from(RawChunk::from_bytes(BYTES).unwrap().0).unwrap();
+        let bytes = Bytes::from_static(BYTES);
+        let abort = AbortChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap();
         assert_eq!(abort.error_causes.len(), 1);
         match &abort.error_causes[0] {
             ErrorCause::UserInitiatedAbort(c) => {
@@ -104,6 +106,7 @@ mod tests {
 
         let mut serialized = vec![0; chunk.serialized_size()];
         chunk.serialize_to(&mut serialized);
-        AbortChunk::try_from(RawChunk::from_bytes(&serialized).unwrap().0).unwrap();
+        let bytes = Bytes::copy_from_slice(&serialized);
+        AbortChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap();
     }
 }

--- a/src/packet/chunk.rs
+++ b/src/packet/chunk.rs
@@ -55,6 +55,7 @@ use crate::packet::shutdown_complete_chunk;
 use crate::packet::shutdown_complete_chunk::ShutdownCompleteChunk;
 use crate::packet::unknown_chunk::UnknownChunk;
 use crate::packet::write_u16_be;
+use bytes::Bytes;
 use std::cmp;
 
 /// Intermediate representation of a chunk for which the type hasn't been fully discriminated, see
@@ -74,12 +75,20 @@ pub(crate) struct RawChunk<'a> {
     pub(crate) typ: u8,
     pub(crate) flags: u8,
     pub(crate) value: &'a [u8],
+    // The backing buffer for the entire packet.
+    pub(crate) packet: &'a Bytes,
+    // The offset where the chunk's value starts within `packet`.
+    pub(crate) value_offset: usize,
 }
 
 impl<'a> RawChunk<'a> {
-    /// Reads a chunk from `bytes` and returns a raw representation of the frame and the remaining
-    /// data that was not consumed when reading this chunk.
-    pub(crate) fn from_bytes(bytes: &'a [u8]) -> Result<(Self, &'a [u8]), ChunkParseError> {
+    /// Reads a chunk from `packet` at the given `offset`.
+    /// Returns the parsed chunk and the next offset to continue parsing from.
+    pub(crate) fn from_bytes(
+        packet: &'a Bytes,
+        offset: usize,
+    ) -> Result<(Self, usize), ChunkParseError> {
+        let bytes = &packet[offset..];
         ensure!(bytes.len() >= TLV_HEADER_SIZE, ChunkParseError::InvalidLength);
 
         let length = read_u16_be!(&bytes[2..4]) as usize;
@@ -87,10 +96,16 @@ impl<'a> RawChunk<'a> {
 
         let padded_length = round_up_to_4!(length);
         let end_offset = cmp::min(padded_length, bytes.len());
-
+        let next_offset = offset + end_offset;
         Ok((
-            Self { typ: bytes[0], flags: bytes[1], value: &bytes[TLV_HEADER_SIZE..length] },
-            &bytes[end_offset..],
+            Self {
+                typ: bytes[0],
+                flags: bytes[1],
+                value: &bytes[TLV_HEADER_SIZE..length],
+                packet,
+                value_offset: offset + TLV_HEADER_SIZE,
+            },
+            next_offset,
         ))
     }
 }
@@ -197,6 +212,7 @@ mod tests {
     use super::*;
     use crate::packet::read_u32_be;
     use crate::packet::write_u32_be;
+    use bytes::Bytes;
 
     // A test chunk that has a single u32 in its header, following the common chunk header.
     #[derive(Debug)]
@@ -230,7 +246,8 @@ mod tests {
     #[test]
     fn parse_success() {
         const BYTES: &[u8] = &[0x42, 0x00, 0x00, 0x08, 0x01, 0x02, 0x03, 0x04];
-        let desc = RawChunk::from_bytes(BYTES).unwrap().0;
+        let bytes = Bytes::from_static(BYTES);
+        let desc = RawChunk::from_bytes(&bytes, 0).unwrap().0;
         let parsed = TestChunk::try_from(desc).unwrap();
         assert_eq!(parsed.additional_data, 0x01020304);
     }
@@ -248,14 +265,16 @@ mod tests {
     #[test]
     fn parse_insufficient_size() {
         const BYTES: &[u8] = &[0x42, 0x00, 0x00];
-        assert_eq!(RawChunk::from_bytes(BYTES).unwrap_err(), ChunkParseError::InvalidLength);
+        let bytes = Bytes::from_static(BYTES);
+        assert_eq!(RawChunk::from_bytes(&bytes, 0).unwrap_err(), ChunkParseError::InvalidLength);
     }
 
     #[test]
     fn parse_invalid_type() {
         const BYTES: &[u8] = &[0x41, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00];
+        let bytes = Bytes::from_static(BYTES);
         assert_eq!(
-            TestChunk::try_from(RawChunk::from_bytes(BYTES).unwrap().0).unwrap_err(),
+            TestChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap_err(),
             ChunkParseError::InvalidType,
         );
     }
@@ -263,8 +282,9 @@ mod tests {
     #[test]
     fn parse_invalid_length() {
         const BYTES: &[u8] = &[0x42, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00];
+        let bytes = Bytes::from_static(BYTES);
         assert_eq!(
-            TestChunk::try_from(RawChunk::from_bytes(BYTES).unwrap().0).unwrap_err(),
+            TestChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap_err(),
             ChunkParseError::InvalidLength,
         );
     }
@@ -298,15 +318,16 @@ mod tests {
             0x61, 0x6e, 0x6e, 0x65, 0x6c, 0x00, 0x00, 0x00,
         ];
         const DATA_HEADER_SIZE: usize = 16;
-        let (chunk, remaining) = RawChunk::from_bytes(BYTES).unwrap();
+        let bytes = Bytes::from_static(BYTES);
+        let (chunk, offset) = RawChunk::from_bytes(&bytes, 0).unwrap();
         assert_eq!(chunk.typ, 0x0b);
         assert!(chunk.value.is_empty());
-        assert_eq!(remaining.len(), round_up_to_4!(DATA_HEADER_SIZE + 41));
+        assert_eq!(bytes.len() - offset, round_up_to_4!(DATA_HEADER_SIZE + 41));
 
-        let (chunk, remaining) = RawChunk::from_bytes(remaining).unwrap();
+        let (chunk, offset) = RawChunk::from_bytes(&bytes, offset).unwrap();
         assert_eq!(chunk.typ, 0x00);
         assert_eq!(chunk.value.len(), DATA_HEADER_SIZE - TLV_HEADER_SIZE + 41);
-        assert!(remaining.is_empty());
+        assert_eq!(offset, bytes.len());
     }
 
     #[test]
@@ -338,7 +359,8 @@ mod tests {
             0x61, 0x6e, 0x6e, 0x65, 0x6c, 0x00, 0x00, 0x00,
         ];
         const DATA_HEADER_SIZE: usize = 16;
-        let (raw_chunk, remaining) = RawChunk::from_bytes(BYTES).unwrap();
+        let bytes = Bytes::from_static(BYTES);
+        let (raw_chunk, offset) = RawChunk::from_bytes(&bytes, 0).unwrap();
         let chunk = Chunk::try_from(raw_chunk).unwrap();
         assert!(matches!(chunk, Chunk::CookieAck { .. }));
         assert_eq!(chunk.as_serializable().serialized_size(), 4);
@@ -346,7 +368,7 @@ mod tests {
         chunk.as_serializable().serialize_to(&mut data1);
         assert_eq!(data1, BYTES[0..4]);
 
-        let (raw_chunk, _remaining) = RawChunk::from_bytes(remaining).unwrap();
+        let (raw_chunk, _offset) = RawChunk::from_bytes(&bytes, offset).unwrap();
         let chunk = Chunk::try_from(raw_chunk).unwrap();
         assert!(matches!(chunk, Chunk::Data { .. }));
         assert_eq!(chunk.as_serializable().serialized_size(), 57);

--- a/src/packet/cookie_ack_chunk.rs
+++ b/src/packet/cookie_ack_chunk.rs
@@ -62,6 +62,7 @@ impl fmt::Display for CookieAckChunk {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bytes::Bytes;
 
     #[test]
     fn init_from_capture() {
@@ -70,7 +71,8 @@ mod tests {
         //   Chunk flags: 0x00
         //   Chunk length: 4
         const BYTES: &[u8] = &[0x0b, 0x00, 0x00, 0x04];
-        CookieAckChunk::try_from(RawChunk::from_bytes(BYTES).unwrap().0).unwrap();
+        let bytes = Bytes::from_static(BYTES);
+        CookieAckChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap();
     }
 
     #[test]
@@ -79,7 +81,8 @@ mod tests {
 
         let mut serialized = vec![0; chunk.serialized_size()];
         chunk.serialize_to(&mut serialized);
-        CookieAckChunk::try_from(RawChunk::from_bytes(&serialized).unwrap().0).unwrap();
+        let bytes = Bytes::copy_from_slice(&serialized);
+        CookieAckChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap();
     }
 
     #[test]

--- a/src/packet/cookie_echo_chunk.rs
+++ b/src/packet/cookie_echo_chunk.rs
@@ -70,11 +70,13 @@ impl fmt::Display for CookieEchoChunk {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bytes::Bytes;
 
     #[test]
     fn init_from_capture() {
         const BYTES: &[u8] = &[0x0a, 0x00, 0x00, 0x08, 0x12, 0x34, 0x56, 0x78];
-        let c = CookieEchoChunk::try_from(RawChunk::from_bytes(BYTES).unwrap().0).unwrap();
+        let bytes = Bytes::from_static(BYTES);
+        let c = CookieEchoChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap();
 
         assert_eq!(c.cookie, vec![0x12, 0x34, 0x56, 0x78]);
     }
@@ -86,8 +88,9 @@ mod tests {
         let mut serialized = vec![0; chunk.serialized_size()];
         chunk.serialize_to(&mut serialized);
 
+        let bytes = Bytes::copy_from_slice(&serialized);
         let deserialized =
-            CookieEchoChunk::try_from(RawChunk::from_bytes(&serialized).unwrap().0).unwrap();
+            CookieEchoChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap();
 
         assert_eq!(deserialized.cookie, vec![1, 2, 3, 4, 5]);
     }

--- a/src/packet/data.rs
+++ b/src/packet/data.rs
@@ -18,6 +18,7 @@ use crate::types::Fsn;
 use crate::types::Mid;
 use crate::types::Ssn;
 use crate::types::StreamKey;
+use bytes::Bytes;
 
 /// Represents data that is either received and extracted from a DATA/I-DATA chunk, or data that is
 /// supposed to be sent, and wrapped in a DATA/I-DATA chunk (depending on peer capabilities).
@@ -34,7 +35,7 @@ pub(crate) struct Data {
     pub mid: Mid,
     pub fsn: Fsn,
     pub ppid: PpId,
-    pub payload: Vec<u8>,
+    pub payload: Bytes,
     pub is_beginning: bool,
     pub is_end: bool,
 }

--- a/src/packet/data_chunk.rs
+++ b/src/packet/data_chunk.rs
@@ -73,11 +73,16 @@ impl TryFrom<RawChunk<'_>> for DataChunk {
         let tsn = Tsn(read_u32_be!(&raw.value[0..4]));
         let is_unordered = raw.flags & (1 << FLAGS_BIT_UNORDERED) != 0;
         let stream_key = StreamKey::new(is_unordered, StreamId(read_u16_be!(&raw.value[4..6])));
+
+        let payload_offset = raw.value_offset + 12;
+        let payload_length = raw.value.len() - 12;
+        let payload = raw.packet.slice(payload_offset..payload_offset + payload_length);
+
         let data = Data {
             stream_key,
             ssn: Ssn(read_u16_be!(&raw.value[6..8])),
             ppid: PpId(read_u32_be!(&raw.value[8..12])),
-            payload: raw.value[12..].to_vec(),
+            payload,
             is_beginning: (raw.flags & (1 << FLAGS_BIT_BEGINNING)) != 0,
             is_end: (raw.flags & (1 << FLAGS_BIT_END)) != 0,
             ..Default::default()
@@ -139,6 +144,7 @@ impl fmt::Display for DataChunk {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bytes::Bytes;
 
     #[test]
     fn from_capture() {
@@ -155,7 +161,8 @@ mod tests {
             0x00, 0x03, 0x00, 0x14, 0x55, 0x08, 0x36, 0x3c, 0x00, 0x02, 0x00, 0x01, 0x00, 0x00,
             0x00, 0x35, 0x00, 0x01, 0x02, 0x03,
         ];
-        let c = DataChunk::try_from(RawChunk::from_bytes(BYTES).unwrap().0).unwrap();
+        let bytes = Bytes::from_static(BYTES);
+        let c = DataChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap();
         assert_eq!(c.tsn, Tsn(1426601532));
         assert_eq!(c.data.stream_key, StreamKey::Ordered(StreamId(2)));
         assert_eq!(c.data.ssn, Ssn(1));
@@ -173,15 +180,15 @@ mod tests {
                 stream_key: StreamKey::Ordered(StreamId(456)),
                 ssn: Ssn(789),
                 ppid: PpId(9090),
-                payload: vec![1, 2, 3, 4, 5],
+                payload: vec![1, 2, 3, 4, 5].into(),
                 ..Default::default()
             },
         };
         let mut serialized = vec![0; chunk.serialized_size()];
         chunk.serialize_to(&mut serialized);
 
-        let deserialized =
-            DataChunk::try_from(RawChunk::from_bytes(&serialized).unwrap().0).unwrap();
+        let bytes = Bytes::copy_from_slice(&serialized);
+        let deserialized = DataChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap();
         assert_eq!(deserialized.tsn, Tsn(123));
         assert_eq!(deserialized.data.stream_key, StreamKey::Ordered(StreamId(456)));
         assert_eq!(deserialized.data.ssn, Ssn(789));

--- a/src/packet/error_chunk.rs
+++ b/src/packet/error_chunk.rs
@@ -77,6 +77,7 @@ impl fmt::Display for ErrorChunk {
 mod tests {
     use super::*;
     use crate::packet::unrecognized_chunk_error_cause::UnrecognizedChunkErrorCause;
+    use bytes::Bytes;
 
     #[test]
     fn init_from_capture() {
@@ -87,7 +88,8 @@ mod tests {
         //    Unrecognized chunk type cause (Type: 73 (unknown))
         const BYTES: &[u8] =
             &[0x09, 0x00, 0x00, 0x0c, 0x00, 0x06, 0x00, 0x08, 0x49, 0x00, 0x00, 0x04];
-        let error = ErrorChunk::try_from(RawChunk::from_bytes(BYTES).unwrap().0).unwrap();
+        let bytes = Bytes::from_static(BYTES);
+        let error = ErrorChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap();
         assert_eq!(error.error_causes.len(), 1);
         match &error.error_causes[0] {
             ErrorCause::UnrecognizedChunk(c) => {
@@ -107,7 +109,8 @@ mod tests {
 
         let mut serialized = vec![0; chunk.serialized_size()];
         chunk.serialize_to(&mut serialized);
-        let parsed = ErrorChunk::try_from(RawChunk::from_bytes(&serialized).unwrap().0).unwrap();
+        let bytes = Bytes::copy_from_slice(&serialized);
+        let parsed = ErrorChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap();
         match &parsed.error_causes[0] {
             ErrorCause::UnrecognizedChunk(c) => {
                 assert_eq!(c.chunk, vec![1, 2, 3, 4]);

--- a/src/packet/forward_tsn_chunk.rs
+++ b/src/packet/forward_tsn_chunk.rs
@@ -112,6 +112,7 @@ impl fmt::Display for ForwardTsnChunk {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bytes::Bytes;
 
     #[test]
     fn from_capture() {
@@ -121,7 +122,8 @@ mod tests {
         //     Chunk length: 8
         //     New cumulative TSN: 1905748778
         const BYTES: &[u8] = &[0xc0, 0x00, 0x00, 0x08, 0x71, 0x97, 0x6b, 0x2a];
-        let c = ForwardTsnChunk::try_from(RawChunk::from_bytes(BYTES).unwrap().0).unwrap();
+        let bytes = Bytes::from_static(BYTES);
+        let c = ForwardTsnChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap();
         assert_eq!(c.new_cumulative_tsn, Tsn(1905748778));
     }
 
@@ -138,8 +140,9 @@ mod tests {
         let mut serialized = vec![0; chunk.serialized_size()];
         chunk.serialize_to(&mut serialized);
 
+        let bytes = Bytes::copy_from_slice(&serialized);
         let deserialized =
-            ForwardTsnChunk::try_from(RawChunk::from_bytes(&serialized).unwrap().0).unwrap();
+            ForwardTsnChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap();
 
         assert_eq!(deserialized.new_cumulative_tsn, Tsn(123));
         assert_eq!(deserialized.skipped_streams.len(), 2);

--- a/src/packet/heartbeat_ack_chunk.rs
+++ b/src/packet/heartbeat_ack_chunk.rs
@@ -75,6 +75,7 @@ impl fmt::Display for HeartbeatAckChunk {
 mod tests {
     use super::*;
     use crate::packet::heartbeat_info_parameter::HeartbeatInfoParameter;
+    use bytes::Bytes;
 
     #[test]
     fn from_capture() {
@@ -92,7 +93,9 @@ mod tests {
             0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00,
         ];
-        let chunk = HeartbeatAckChunk::try_from(RawChunk::from_bytes(BYTES).unwrap().0).unwrap();
+        let bytes = Bytes::from_static(BYTES);
+        let chunk =
+            HeartbeatAckChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap();
         assert_eq!(chunk.parameters.len(), 1);
 
         const HEARTBEAT_INFO_BYTES: &[u8] = &[
@@ -122,8 +125,9 @@ mod tests {
 
         let mut serialized = vec![0; chunk.serialized_size()];
         chunk.serialize_to(&mut serialized);
+        let bytes = Bytes::copy_from_slice(&serialized);
         let deserialized =
-            HeartbeatAckChunk::try_from(RawChunk::from_bytes(&serialized).unwrap().0).unwrap();
+            HeartbeatAckChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap();
         match deserialized.parameters[0] {
             Parameter::HeartbeatInfo(ref i) if i.info == info => {}
             _ => panic!(),

--- a/src/packet/heartbeat_request_chunk.rs
+++ b/src/packet/heartbeat_request_chunk.rs
@@ -75,6 +75,7 @@ impl fmt::Display for HeartbeatRequestChunk {
 mod tests {
     use super::*;
     use crate::packet::heartbeat_info_parameter::HeartbeatInfoParameter;
+    use bytes::Bytes;
 
     #[test]
     fn from_capture() {
@@ -92,8 +93,9 @@ mod tests {
             0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00,
         ];
+        let bytes = Bytes::from_static(BYTES);
         let chunk =
-            HeartbeatRequestChunk::try_from(RawChunk::from_bytes(BYTES).unwrap().0).unwrap();
+            HeartbeatRequestChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap();
         assert_eq!(chunk.parameters.len(), 1);
 
         const HEARTBEAT_INFO_BYTES: &[u8] = &[
@@ -120,8 +122,9 @@ mod tests {
 
         let mut serialized = vec![0; chunk.serialized_size()];
         chunk.serialize_to(&mut serialized);
+        let bytes = Bytes::copy_from_slice(&serialized);
         let deserialized =
-            HeartbeatRequestChunk::try_from(RawChunk::from_bytes(&serialized).unwrap().0).unwrap();
+            HeartbeatRequestChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap();
 
         match deserialized.parameters[0] {
             Parameter::HeartbeatInfo(ref i) if i.info == info => {}

--- a/src/packet/idata_chunk.rs
+++ b/src/packet/idata_chunk.rs
@@ -79,12 +79,17 @@ impl TryFrom<RawChunk<'_>> for IDataChunk {
         let (ppid, fsn) = if is_beginning { (ppid_or_fsn, 0) } else { (0, ppid_or_fsn) };
         let stream_id = StreamId(read_u16_be!(&raw.value[4..6]));
         let is_unordered = (raw.flags & (1 << FLAGS_BIT_UNORDERED)) != 0;
+
+        let payload_offset = raw.value_offset + 16;
+        let payload_length = raw.value.len() - 16;
+        let payload = raw.packet.slice(payload_offset..payload_offset + payload_length);
+
         let data = Data {
             stream_key: StreamKey::new(is_unordered, stream_id),
             mid: Mid(read_u32_be!(&raw.value[8..12])),
             ppid: PpId(ppid),
             fsn: Fsn(fsn),
-            payload: raw.value[16..].to_vec(),
+            payload,
             is_beginning,
             is_end: (raw.flags & (1 << FLAGS_BIT_END)) != 0,
             ..Default::default()
@@ -148,6 +153,7 @@ impl fmt::Display for IDataChunk {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bytes::Bytes;
 
     #[test]
     fn at_beginning_from_capture() {
@@ -166,7 +172,8 @@ mod tests {
             0x40, 0x02, 0x00, 0x15, 0x94, 0x4a, 0x5d, 0xd5, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x35, 0x01, 0x00, 0x00, 0x00,
         ];
-        let c = IDataChunk::try_from(RawChunk::from_bytes(BYTES).unwrap().0).unwrap();
+        let bytes = Bytes::from_static(BYTES);
+        let c = IDataChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap();
         assert_eq!(c.tsn, Tsn(2487901653));
         assert_eq!(c.data.stream_key, StreamKey::Ordered(StreamId(1)));
         assert_eq!(c.data.mid, Mid(0));
@@ -185,7 +192,7 @@ mod tests {
                 stream_key: StreamKey::Ordered(StreamId(456)),
                 mid: Mid(789),
                 ppid: PpId(9090),
-                payload: vec![1, 2, 3, 4, 5],
+                payload: vec![1, 2, 3, 4, 5].into(),
                 is_beginning: true,
                 ..Default::default()
             },
@@ -193,8 +200,9 @@ mod tests {
         let mut serialized = vec![0; chunk.serialized_size()];
         chunk.serialize_to(&mut serialized);
 
+        let bytes = Bytes::copy_from_slice(&serialized);
         let deserialized =
-            IDataChunk::try_from(RawChunk::from_bytes(&serialized).unwrap().0).unwrap();
+            IDataChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap();
         assert_eq!(deserialized.tsn, Tsn(123));
         assert_eq!(deserialized.data.stream_key, StreamKey::Ordered(StreamId(456)));
         assert_eq!(deserialized.data.mid, Mid(789));
@@ -224,7 +232,8 @@ mod tests {
             0x40, 0x01, 0x00, 0x15, 0x94, 0x4a, 0x5e, 0x0a, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x01, 0x00, 0x00, 0x00, 0x08, 0x01, 0x00, 0x00, 0x00,
         ];
-        let c = IDataChunk::try_from(RawChunk::from_bytes(BYTES).unwrap().0).unwrap();
+        let bytes = Bytes::from_static(BYTES);
+        let c = IDataChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap();
         assert_eq!(c.tsn, Tsn(2487901706));
         assert_eq!(c.data.stream_key, StreamKey::Ordered(StreamId(3)));
         assert_eq!(c.data.mid, Mid(1));
@@ -243,15 +252,16 @@ mod tests {
                 stream_key: StreamKey::Ordered(StreamId(456)),
                 mid: Mid(789),
                 fsn: Fsn(10),
-                payload: vec![1, 2, 3, 4, 5],
+                payload: vec![1, 2, 3, 4, 5].into(),
                 ..Default::default()
             },
         };
         let mut serialized = vec![0; chunk.serialized_size()];
         chunk.serialize_to(&mut serialized);
 
+        let bytes = Bytes::copy_from_slice(&serialized);
         let deserialized =
-            IDataChunk::try_from(RawChunk::from_bytes(&serialized).unwrap().0).unwrap();
+            IDataChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap();
         assert_eq!(deserialized.tsn, Tsn(123));
         assert_eq!(deserialized.data.stream_key, StreamKey::Ordered(StreamId(456)));
         assert_eq!(deserialized.data.mid, Mid(789));

--- a/src/packet/iforward_tsn_chunk.rs
+++ b/src/packet/iforward_tsn_chunk.rs
@@ -120,6 +120,7 @@ impl fmt::Display for IForwardTsnChunk {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bytes::Bytes;
 
     #[test]
     fn from_capture() {
@@ -135,7 +136,8 @@ mod tests {
             0xc2, 0x00, 0x00, 0x10, 0xb8, 0x74, 0x52, 0xec, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x02,
         ];
-        let c = IForwardTsnChunk::try_from(RawChunk::from_bytes(BYTES).unwrap().0).unwrap();
+        let bytes = Bytes::from_static(BYTES);
+        let c = IForwardTsnChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap();
         assert_eq!(c.new_cumulative_tsn, Tsn(3094631148));
         assert_eq!(
             c.skipped_streams,
@@ -156,8 +158,9 @@ mod tests {
         let mut serialized = vec![0; chunk.serialized_size()];
         chunk.serialize_to(&mut serialized);
 
+        let bytes = Bytes::copy_from_slice(&serialized);
         let deserialized =
-            IForwardTsnChunk::try_from(RawChunk::from_bytes(&serialized).unwrap().0).unwrap();
+            IForwardTsnChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap();
 
         assert_eq!(deserialized.new_cumulative_tsn, Tsn(123));
         assert_eq!(deserialized.skipped_streams.len(), 2);

--- a/src/packet/init_ack_chunk.rs
+++ b/src/packet/init_ack_chunk.rs
@@ -116,6 +116,7 @@ impl fmt::Display for InitAckChunk {
 mod tests {
     use super::*;
     use crate::packet::state_cookie_parameter::StateCookieParameter;
+    use bytes::Bytes;
 
     #[test]
     fn init_ack_from_capture() {
@@ -142,7 +143,8 @@ mod tests {
             0x00, 0x06, 0xc0, 0x82, 0x00, 0x00, 0x51, 0x95, 0x01, 0x88, 0x0d, 0x80, 0x7b, 0x19,
             0xe7, 0xf9, 0xc6, 0x18, 0x5c, 0x4a, 0xbf, 0x39, 0x32, 0xe5, 0x63, 0x8e,
         ];
-        let c = InitAckChunk::try_from(RawChunk::from_bytes(BYTES).unwrap().0).unwrap();
+        let bytes = Bytes::from_static(BYTES);
+        let c = InitAckChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap();
 
         assert_eq!(c.initiate_tag, 0x579c2f98);
         assert_eq!(c.a_rwnd, 131072);
@@ -172,8 +174,9 @@ mod tests {
         let mut serialized = vec![0; chunk.serialized_size()];
         chunk.serialize_to(&mut serialized);
 
+        let bytes = Bytes::copy_from_slice(&serialized);
         let deserialized =
-            InitAckChunk::try_from(RawChunk::from_bytes(&serialized).unwrap().0).unwrap();
+            InitAckChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap();
 
         assert_eq!(deserialized.initiate_tag, 123);
         assert_eq!(deserialized.a_rwnd, 456);

--- a/src/packet/init_chunk.rs
+++ b/src/packet/init_chunk.rs
@@ -113,6 +113,7 @@ mod tests {
     use super::*;
     use crate::packet::forward_tsn_supported_parameter::ForwardTsnSupportedParameter;
     use crate::packet::supported_extensions_parameter::SupportedExtensionsParameter;
+    use bytes::Bytes;
 
     #[test]
     fn init_from_capture() {
@@ -125,7 +126,8 @@ mod tests {
             0xa6, 0x44, 0xce, 0x4d, 0xd2, 0xad, 0x80, 0x04, 0x00, 0x06, 0x00, 0x01, 0x00, 0x00,
             0x80, 0x03, 0x00, 0x06, 0x80, 0xc1, 0x00, 0x00,
         ];
-        let c = InitChunk::try_from(RawChunk::from_bytes(BYTES).unwrap().0).unwrap();
+        let bytes = Bytes::from_static(BYTES);
+        let c = InitChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap();
 
         assert_eq!(c.initiate_tag, 0xde7a1690);
         assert_eq!(c.a_rwnd, 131072);
@@ -158,8 +160,8 @@ mod tests {
         let mut serialized = vec![0; chunk.serialized_size()];
         chunk.serialize_to(&mut serialized);
 
-        let deserialized =
-            InitChunk::try_from(RawChunk::from_bytes(&serialized).unwrap().0).unwrap();
+        let bytes = Bytes::copy_from_slice(&serialized);
+        let deserialized = InitChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap();
 
         assert_eq!(deserialized.initiate_tag, 123);
         assert_eq!(deserialized.a_rwnd, 456);

--- a/src/packet/re_config_chunk.rs
+++ b/src/packet/re_config_chunk.rs
@@ -80,6 +80,7 @@ mod tests {
     use crate::api::StreamId;
     use crate::packet::outgoing_ssn_reset_request_parameter::OutgoingSsnResetRequestParameter;
     use crate::types::Tsn;
+    use bytes::Bytes;
 
     #[test]
     fn from_capture() {
@@ -99,7 +100,8 @@ mod tests {
             0x82, 0x00, 0x00, 0x16, 0x00, 0x0d, 0x00, 0x12, 0x87, 0x55, 0xd8, 0x23, 0x71, 0x97,
             0x6a, 0x9e, 0x87, 0x55, 0xd8, 0x32, 0x00, 0x06, 0x00, 0x00,
         ];
-        let chunk = ReConfigChunk::try_from(RawChunk::from_bytes(BYTES).unwrap().0).unwrap();
+        let bytes = Bytes::from_static(BYTES);
+        let chunk = ReConfigChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap();
         assert_eq!(chunk.parameters.len(), 1);
         match chunk.parameters[0] {
             Parameter::OutgoingSsnResetRequest(ref i) => {
@@ -128,8 +130,9 @@ mod tests {
         let mut serialized = vec![0; chunk.serialized_size()];
         chunk.serialize_to(&mut serialized);
 
+        let bytes = Bytes::copy_from_slice(&serialized);
         let deserialized =
-            ReConfigChunk::try_from(RawChunk::from_bytes(&serialized).unwrap().0).unwrap();
+            ReConfigChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap();
         match deserialized.parameters[0] {
             Parameter::OutgoingSsnResetRequest(ref i) => {
                 assert_eq!(i.request_seq_nbr, 123);

--- a/src/packet/sack_chunk.rs
+++ b/src/packet/sack_chunk.rs
@@ -150,6 +150,7 @@ impl fmt::Display for SackChunk {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bytes::Bytes;
 
     #[test]
     fn from_capture() {
@@ -157,7 +158,8 @@ mod tests {
             0x03, 0x00, 0x00, 0x1c, 0x36, 0x9d, 0xd0, 0x0b, 0x00, 0x01, 0xed, 0x73, 0x00, 0x02,
             0x00, 0x01, 0x00, 0x02, 0x00, 0x06, 0x00, 0x08, 0x00, 0x08, 0x36, 0x9d, 0xd0, 0x11,
         ];
-        let c = SackChunk::try_from(RawChunk::from_bytes(BYTES).unwrap().0).unwrap();
+        let bytes = Bytes::from_static(BYTES);
+        let c = SackChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap();
 
         let cum_ack_tsn = 916312075;
         assert_eq!(c.cumulative_tsn_ack, Tsn(cum_ack_tsn));
@@ -183,8 +185,8 @@ mod tests {
         let mut serialized = vec![0; chunk.serialized_size()];
         chunk.serialize_to(&mut serialized);
 
-        let deserialized =
-            SackChunk::try_from(RawChunk::from_bytes(&serialized).unwrap().0).unwrap();
+        let bytes = Bytes::copy_from_slice(&serialized);
+        let deserialized = SackChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap();
 
         assert_eq!(deserialized.cumulative_tsn_ack, Tsn(123));
         assert_eq!(deserialized.a_rwnd, 456);

--- a/src/packet/sctp_packet.rs
+++ b/src/packet/sctp_packet.rs
@@ -28,6 +28,7 @@ use crate::packet::read_u32_be;
 use crate::packet::write_u16_be;
 use crate::packet::write_u32_be;
 use bytes::Bytes;
+use bytes::BytesMut;
 use thiserror::Error;
 
 pub const COMMON_HEADER_SIZE: usize = 12;
@@ -83,7 +84,7 @@ impl From<ChunkParseError> for PacketParseError {
 }
 
 impl SctpPacket {
-    pub fn from_bytes(data: &[u8], options: &Options) -> Result<SctpPacket, PacketParseError> {
+    pub fn from_bytes(data: Bytes, options: &Options) -> Result<SctpPacket, PacketParseError> {
         ensure!(
             data.len() >= COMMON_HEADER_SIZE + CHUNK_TLV_SIZE && data.len() <= MAX_PACKET_SIZE,
             PacketParseError::InvalidPacketSize
@@ -121,14 +122,14 @@ impl SctpPacket {
         }
 
         let mut chunks: Vec<Chunk> = Vec::with_capacity(4);
-        let mut remaining = &data[COMMON_HEADER_SIZE..];
+        let mut offset = COMMON_HEADER_SIZE;
 
-        while !remaining.is_empty() {
-            let (raw, next_remaining) = RawChunk::from_bytes(remaining)?;
+        while offset < data.len() {
+            let (raw, next_offset) = RawChunk::from_bytes(&data, offset)?;
             let chunk = Chunk::try_from(raw)?;
             chunks.push(chunk);
 
-            remaining = next_remaining;
+            offset = next_offset;
         }
 
         Ok(SctpPacket { common_header, chunks })
@@ -141,7 +142,7 @@ pub(crate) struct SctpPacketBuilder {
     dest_port: u16,
     max_packet_size: usize,
     write_checksum: bool,
-    data: Vec<u8>,
+    data: BytesMut,
 }
 
 impl SctpPacketBuilder {
@@ -157,7 +158,7 @@ impl SctpPacketBuilder {
             dest_port,
             max_packet_size: round_down_to_4!(max_packet_size),
             write_checksum: true,
-            data: vec![],
+            data: BytesMut::new(),
         }
     }
 
@@ -201,15 +202,14 @@ impl SctpPacketBuilder {
     }
 
     pub fn build(&mut self) -> Bytes {
-        let mut out = Vec::<u8>::new();
         if self.write_checksum && !self.data.is_empty() {
             let mut crc = Crc32c::new();
             crc.digest(&self.data);
             let checksum = crc.value().to_be();
             write_u32_be!(&mut self.data[8..12], checksum);
         }
-        std::mem::swap(&mut self.data, &mut out);
-        out.into()
+        let out = std::mem::take(&mut self.data);
+        out.freeze()
     }
 }
 
@@ -231,6 +231,7 @@ mod tests {
     use crate::types::Ssn;
     use crate::types::StreamKey;
     use crate::types::Tsn;
+    use bytes::Bytes;
 
     const VERIFICATION_TAG: u32 = 0x12345678;
 
@@ -291,7 +292,8 @@ mod tests {
             0x00, 0x06, 0x80, 0xc1, 0x00, 0x00,
         ];
 
-        let packet = SctpPacket::from_bytes(bytes, &Options::default()).unwrap();
+        let packet =
+            SctpPacket::from_bytes(Bytes::copy_from_slice(bytes), &Options::default()).unwrap();
         assert_eq!(packet.common_header.source_port, 5000);
         assert_eq!(packet.common_header.destination_port, 5000);
         assert_eq!(packet.common_header.verification_tag, 0);
@@ -333,7 +335,8 @@ mod tests {
             0x00, 0x00, 0x00, 0x00,
         ];
 
-        let packet = SctpPacket::from_bytes(bytes, &Options::default()).unwrap();
+        let packet =
+            SctpPacket::from_bytes(Bytes::copy_from_slice(bytes), &Options::default()).unwrap();
         assert_eq!(packet.common_header.source_port, 1234);
         assert_eq!(packet.common_header.destination_port, 4321);
         assert_eq!(packet.common_header.verification_tag, 0x697e3a4e);
@@ -368,7 +371,7 @@ mod tests {
             0x00, 0x10, 0x55, 0x08, 0x36, 0x40, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         ];
 
-        let packet = SctpPacket::from_bytes(bytes, &Options::default());
+        let packet = SctpPacket::from_bytes(Bytes::copy_from_slice(bytes), &Options::default());
         assert!(packet.is_err());
     }
 
@@ -397,7 +400,7 @@ mod tests {
         ];
 
         let options = &Options { disable_checksum_verification: true, ..Default::default() };
-        let packet = SctpPacket::from_bytes(bytes, options).unwrap();
+        let packet = SctpPacket::from_bytes(Bytes::copy_from_slice(bytes), options).unwrap();
 
         assert_eq!(packet.common_header.source_port, 5000);
         assert_eq!(packet.common_header.destination_port, 5000);
@@ -426,7 +429,7 @@ mod tests {
         }));
         let serialized = b.build();
 
-        let packet = SctpPacket::from_bytes(&serialized, &Options::default()).unwrap();
+        let packet = SctpPacket::from_bytes(serialized, &Options::default()).unwrap();
 
         assert_eq!(packet.common_header.verification_tag, VERIFICATION_TAG);
         assert_eq!(packet.chunks.len(), 1);
@@ -463,7 +466,7 @@ mod tests {
                 stream_key: StreamKey::Ordered(StreamId(456)),
                 ssn: Ssn(789),
                 ppid: PpId(9090),
-                payload: vec![1, 2, 3, 4, 5],
+                payload: vec![1, 2, 3, 4, 5].into(),
                 ..Default::default()
             },
         }));
@@ -473,13 +476,13 @@ mod tests {
                 stream_key: StreamKey::Ordered(StreamId(654)),
                 ssn: Ssn(789),
                 ppid: PpId(909),
-                payload: vec![5, 4, 3, 2, 1],
+                payload: vec![5, 4, 3, 2, 1].into(),
                 ..Default::default()
             },
         }));
         let serialized = b.build();
 
-        let packet = SctpPacket::from_bytes(&serialized, &Options::default()).unwrap();
+        let packet = SctpPacket::from_bytes(serialized, &Options::default()).unwrap();
 
         assert_eq!(packet.common_header.verification_tag, VERIFICATION_TAG);
         assert_eq!(packet.chunks.len(), 3);
@@ -514,7 +517,7 @@ mod tests {
         }))
         .build();
 
-        let packet = SctpPacket::from_bytes(&bytes, &Default::default()).unwrap();
+        let packet = SctpPacket::from_bytes(bytes, &Default::default()).unwrap();
         assert_eq!(packet.chunks.len(), 1);
         let Chunk::Abort(abort) = &packet.chunks[0] else {
             panic!();
@@ -533,7 +536,7 @@ mod tests {
             0x00, 0x00, 0x00,
         ];
 
-        let packet = SctpPacket::from_bytes(bytes, &Options::default());
+        let packet = SctpPacket::from_bytes(Bytes::copy_from_slice(bytes), &Options::default());
         assert!(packet.is_err());
     }
 
@@ -560,7 +563,7 @@ mod tests {
         let payload = vec![0; 183];
         builder.add(&Chunk::Data(DataChunk {
             tsn: Tsn(1),
-            data: Data { payload: payload.clone(), ..Default::default() },
+            data: Data { payload: payload.clone().into(), ..Default::default() },
         }));
         let chunk1_size = round_up_to_4!(data_chunk::HEADER_SIZE + payload.len());
         assert_eq!(
@@ -572,7 +575,7 @@ mod tests {
         let payload = vec![0; 957];
         builder.add(&Chunk::Data(DataChunk {
             tsn: Tsn(2),
-            data: Data { payload: payload.clone(), ..Default::default() },
+            data: Data { payload: payload.clone().into(), ..Default::default() },
         }));
         let chunk2_size = round_up_to_4!(data_chunk::HEADER_SIZE + payload.len());
         assert_eq!(
@@ -612,7 +615,7 @@ mod tests {
                 ZERO_CHECKSUM_ALTERNATE_ERROR_DETECTION_METHOD_LOWER_LAYER_DTLS,
             ..Default::default()
         };
-        let packet = SctpPacket::from_bytes(bytes, &options).unwrap();
+        let packet = SctpPacket::from_bytes(Bytes::copy_from_slice(bytes), &options).unwrap();
 
         assert_eq!(packet.common_header.source_port, 5000);
         assert_eq!(packet.common_header.destination_port, 5000);
@@ -650,7 +653,7 @@ mod tests {
                 ZERO_CHECKSUM_ALTERNATE_ERROR_DETECTION_METHOD_LOWER_LAYER_DTLS,
             ..Default::default()
         };
-        assert!(SctpPacket::from_bytes(bytes, &options).is_err());
+        assert!(SctpPacket::from_bytes(Bytes::copy_from_slice(bytes), &options).is_err());
     }
 
     #[test]

--- a/src/packet/sctp_packet.rs
+++ b/src/packet/sctp_packet.rs
@@ -27,6 +27,7 @@ use crate::packet::read_u16_be;
 use crate::packet::read_u32_be;
 use crate::packet::write_u16_be;
 use crate::packet::write_u32_be;
+use bytes::Bytes;
 use thiserror::Error;
 
 pub const COMMON_HEADER_SIZE: usize = 12;
@@ -199,7 +200,7 @@ impl SctpPacketBuilder {
         self.data.is_empty()
     }
 
-    pub fn build(&mut self) -> Vec<u8> {
+    pub fn build(&mut self) -> Bytes {
         let mut out = Vec::<u8>::new();
         if self.write_checksum && !self.data.is_empty() {
             let mut crc = Crc32c::new();
@@ -208,7 +209,7 @@ impl SctpPacketBuilder {
             write_u32_be!(&mut self.data[8..12], checksum);
         }
         std::mem::swap(&mut self.data, &mut out);
-        out
+        out.into()
     }
 }
 

--- a/src/packet/shutdown_ack_chunk.rs
+++ b/src/packet/shutdown_ack_chunk.rs
@@ -62,6 +62,7 @@ impl fmt::Display for ShutdownAckChunk {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bytes::Bytes;
 
     #[test]
     fn init_from_capture() {
@@ -70,7 +71,8 @@ mod tests {
         //  Chunk flags: 0x00
         //  Chunk length: 4
         const BYTES: &[u8] = &[0x08, 0x00, 0x00, 0x04];
-        ShutdownAckChunk::try_from(RawChunk::from_bytes(BYTES).unwrap().0).unwrap();
+        let bytes = Bytes::from_static(BYTES);
+        ShutdownAckChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap();
     }
 
     #[test]
@@ -79,7 +81,8 @@ mod tests {
 
         let mut serialized = vec![0; chunk.serialized_size()];
         chunk.serialize_to(&mut serialized);
-        ShutdownAckChunk::try_from(RawChunk::from_bytes(&serialized).unwrap().0).unwrap();
+        let bytes = Bytes::copy_from_slice(&serialized);
+        ShutdownAckChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap();
     }
 
     #[test]

--- a/src/packet/shutdown_chunk.rs
+++ b/src/packet/shutdown_chunk.rs
@@ -71,6 +71,7 @@ impl fmt::Display for ShutdownChunk {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bytes::Bytes;
 
     #[test]
     fn from_capture() {
@@ -80,7 +81,8 @@ mod tests {
         //  Chunk length: 8
         //  Cumulative TSN Ack: 101831101
         const BYTES: &[u8] = &[0x07, 0x00, 0x00, 0x08, 0x06, 0x11, 0xd1, 0xbd];
-        let c = ShutdownChunk::try_from(RawChunk::from_bytes(BYTES).unwrap().0).unwrap();
+        let bytes = Bytes::from_static(BYTES);
+        let c = ShutdownChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap();
         assert_eq!(c.cumulative_tsn_ack, Tsn(101831101));
     }
 
@@ -91,8 +93,9 @@ mod tests {
         let mut serialized = vec![0; chunk.serialized_size()];
         chunk.serialize_to(&mut serialized);
 
+        let bytes = Bytes::copy_from_slice(&serialized);
         let deserialized =
-            ShutdownChunk::try_from(RawChunk::from_bytes(&serialized).unwrap().0).unwrap();
+            ShutdownChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap();
 
         assert_eq!(deserialized.cumulative_tsn_ack, Tsn(12345678));
         assert_eq!(deserialized.to_string(), "SHUTDOWN cumulative_tsn_ack=12345678");

--- a/src/packet/shutdown_complete_chunk.rs
+++ b/src/packet/shutdown_complete_chunk.rs
@@ -65,6 +65,7 @@ impl fmt::Display for ShutdownCompleteChunk {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bytes::Bytes;
 
     #[test]
     fn init_from_capture() {
@@ -73,7 +74,8 @@ mod tests {
         //  Chunk flags: 0x00
         //  Chunk length: 4
         const BYTES: &[u8] = &[0x0e, 0x00, 0x00, 0x04];
-        ShutdownCompleteChunk::try_from(RawChunk::from_bytes(BYTES).unwrap().0).unwrap();
+        let bytes = Bytes::from_static(BYTES);
+        ShutdownCompleteChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap();
     }
 
     #[test]
@@ -82,8 +84,9 @@ mod tests {
 
         let mut serialized = vec![0; chunk.serialized_size()];
         chunk.serialize_to(&mut serialized);
+        let bytes = Bytes::copy_from_slice(&serialized);
         let deserialized =
-            ShutdownCompleteChunk::try_from(RawChunk::from_bytes(&serialized).unwrap().0).unwrap();
+            ShutdownCompleteChunk::try_from(RawChunk::from_bytes(&bytes, 0).unwrap().0).unwrap();
         assert_eq!(chunk.tag_reflected, deserialized.tag_reflected);
     }
 

--- a/src/rx/interleaved_reassembly_streams.rs
+++ b/src/rx/interleaved_reassembly_streams.rs
@@ -63,7 +63,7 @@ impl OrderedStream {
             let payload = interval.collect_payload();
 
             assembled_bytes += payload.len();
-            on_reassembled(Message::new(stream_id, ppid, payload));
+            on_reassembled(Message::new(stream_id, ppid, payload.into()));
             self.next_mid += 1;
         }
 
@@ -78,7 +78,7 @@ impl OrderedStream {
 
         if data.mid == self.next_mid && data.is_beginning && data.is_end {
             // Fastpath for already assembled chunks.
-            on_reassembled(Message::new(self.stream_id, data.ppid, data.payload));
+            on_reassembled(Message::new(self.stream_id, data.ppid, data.payload.into()));
             self.next_mid += 1;
             let assembled = self.try_assemble_next(on_reassembled);
             return -(assembled as isize);
@@ -105,7 +105,7 @@ impl UnorderedStream {
     fn add(&mut self, data: Data, on_reassembled: &mut dyn FnMut(Message)) -> isize {
         if data.is_beginning && data.is_end {
             // Fast path - reassemble directly.
-            on_reassembled(Message::new(data.stream_key.id(), data.ppid, data.payload));
+            on_reassembled(Message::new(data.stream_key.id(), data.ppid, data.payload.into()));
             return 0;
         }
 
@@ -119,7 +119,7 @@ impl UnorderedStream {
             let payload = interval.collect_payload();
             let total_payload_len = payload.len();
 
-            on_reassembled(Message::new(stream_id, ppid, payload));
+            on_reassembled(Message::new(stream_id, ppid, payload.into()));
             queued_bytes - (total_payload_len as isize)
         } else {
             queued_bytes
@@ -536,7 +536,7 @@ mod tests {
 
         assert_eq!(streams2.add(Tsn(3), data, &mut |m| messages.push(m)), 0);
         assert_eq!(messages.len(), 1);
-        assert_eq!(messages[0].payload, b"efgh");
+        assert_eq!(&messages[0].payload[..], b"efgh");
     }
 
     #[test]
@@ -566,6 +566,6 @@ mod tests {
         let data = seq.unordered("efgh", "BE");
         assert_eq!(streams2.add(Tsn(3), data, &mut |m| messages.push(m)), 0);
         assert_eq!(messages.len(), 1);
-        assert_eq!(messages[0].payload, b"efgh");
+        assert_eq!(&messages[0].payload[..], b"efgh");
     }
 }

--- a/src/rx/interleaved_reassembly_streams.rs
+++ b/src/rx/interleaved_reassembly_streams.rs
@@ -63,7 +63,7 @@ impl OrderedStream {
             let payload = interval.collect_payload();
 
             assembled_bytes += payload.len();
-            on_reassembled(Message::new(stream_id, ppid, payload.into()));
+            on_reassembled(Message::new(stream_id, ppid, payload));
             self.next_mid += 1;
         }
 
@@ -113,13 +113,14 @@ impl UnorderedStream {
         let queued_bytes = data.payload.len() as isize;
         let idx = self.intervals.add(key, data);
 
-        if let Some(interval) = self.intervals.pop_if_complete(idx) {
+        let complete_interval = self.intervals.pop_if_complete(idx);
+        if let Some(interval) = complete_interval {
             let stream_id = self.stream_id;
             let ppid = interval.ppid;
             let payload = interval.collect_payload();
             let total_payload_len = payload.len();
 
-            on_reassembled(Message::new(stream_id, ppid, payload.into()));
+            on_reassembled(Message::new(stream_id, ppid, payload));
             queued_bytes - (total_payload_len as isize)
         } else {
             queued_bytes

--- a/src/rx/interleaved_reassembly_streams.rs
+++ b/src/rx/interleaved_reassembly_streams.rs
@@ -78,7 +78,7 @@ impl OrderedStream {
 
         if data.mid == self.next_mid && data.is_beginning && data.is_end {
             // Fastpath for already assembled chunks.
-            on_reassembled(Message::new(self.stream_id, data.ppid, data.payload.into()));
+            on_reassembled(Message::new(self.stream_id, data.ppid, data.payload));
             self.next_mid += 1;
             let assembled = self.try_assemble_next(on_reassembled);
             return -(assembled as isize);
@@ -105,7 +105,7 @@ impl UnorderedStream {
     fn add(&mut self, data: Data, on_reassembled: &mut dyn FnMut(Message)) -> isize {
         if data.is_beginning && data.is_end {
             // Fast path - reassemble directly.
-            on_reassembled(Message::new(data.stream_key.id(), data.ppid, data.payload.into()));
+            on_reassembled(Message::new(data.stream_key.id(), data.ppid, data.payload));
             return 0;
         }
 

--- a/src/rx/mod.rs
+++ b/src/rx/mod.rs
@@ -14,6 +14,8 @@
 
 use crate::api::PpId;
 use crate::packet::data::Data;
+use bytes::Bytes;
+use bytes::BytesMut;
 use std::collections::VecDeque;
 
 pub mod data_tracker;
@@ -47,22 +49,22 @@ pub struct Interval<K: ReassemblyKey> {
     /// Only valid if `has_beginning` is true (as per RFC 8260).
     pub ppid: PpId,
     /// The payload data chunks that make up this interval.
-    pub payload: VecDeque<Vec<u8>>,
+    pub payload: VecDeque<Bytes>,
 }
 
 impl<K: ReassemblyKey> Interval<K> {
     /// Consumes the interval and returns the assembled payload.
-    pub fn collect_payload(self) -> Vec<u8> {
+    pub fn collect_payload(self) -> Bytes {
         let mut parts = self.payload;
         if parts.len() == 1 {
             parts.pop_front().unwrap()
         } else {
             let total_payload_len = parts.iter().map(|p| p.len()).sum();
-            let mut payload = Vec::with_capacity(total_payload_len);
+            let mut payload = BytesMut::with_capacity(total_payload_len);
             for p in parts {
-                payload.extend(p);
+                payload.extend_from_slice(&p);
             }
-            payload
+            payload.freeze()
         }
     }
 }
@@ -117,14 +119,14 @@ impl<K: ReassemblyKey> IntervalList<K> {
 
             left.end = right.end;
             left.has_end = right.has_end;
-            left.payload.push_back(data.payload);
+            left.payload.push_back(data.payload.into());
             left.payload.append(&mut right.payload);
             idx - 1
         } else if extend_left {
             let left = &mut self.intervals[idx - 1];
             left.end = key;
             left.has_end = data.is_end;
-            left.payload.push_back(data.payload);
+            left.payload.push_back(data.payload.into());
             idx - 1
         } else if extend_right {
             let right = &mut self.intervals[idx];
@@ -135,7 +137,7 @@ impl<K: ReassemblyKey> IntervalList<K> {
             if data.is_beginning {
                 right.ppid = data.ppid;
             }
-            right.payload.push_front(data.payload);
+            right.payload.push_front(data.payload.into());
             idx
         } else {
             // No merge possible, insert new isolated interval.
@@ -147,7 +149,7 @@ impl<K: ReassemblyKey> IntervalList<K> {
                     has_beginning: data.is_beginning,
                     has_end: data.is_end,
                     ppid: data.ppid,
-                    payload: VecDeque::from([data.payload]),
+                    payload: VecDeque::from([data.payload.into()]),
                 },
             );
             idx
@@ -279,7 +281,10 @@ mod tests {
         assert_eq!(list.intervals[0].start, TestKey(Tsn(10)));
         assert_eq!(list.intervals[0].end, TestKey(Tsn(11)));
         // Verify payload order
-        assert_eq!(list.intervals[0].payload, &[b"p0", b"p1"]);
+        assert_eq!(
+            list.intervals[0].payload,
+            VecDeque::from([Bytes::from("p0"), Bytes::from("p1")])
+        );
         // Verify PPID inherited from Begin chunk
         assert_eq!(list.intervals[0].ppid, PpId(53));
     }
@@ -300,13 +305,13 @@ mod tests {
         assert_eq!(list.intervals.len(), 2);
         assert_eq!(list.intervals[0].start, TestKey(Tsn(11)));
         assert_eq!(list.intervals[0].end, TestKey(Tsn(11)));
-        assert_eq!(list.intervals[0].payload, &[b"p1"]);
+        assert_eq!(list.intervals[0].payload, VecDeque::from([Bytes::from("p1")]));
         assert!(!list.intervals[0].has_beginning);
         assert!(list.intervals[0].has_end);
 
         assert_eq!(list.intervals[1].start, TestKey(Tsn(12)));
         assert_eq!(list.intervals[1].end, TestKey(Tsn(12)));
-        assert_eq!(list.intervals[1].payload, &[b"p2"]);
+        assert_eq!(list.intervals[1].payload, VecDeque::from([Bytes::from("p2")]));
         assert!(list.intervals[1].has_beginning);
         assert!(!list.intervals[1].has_end);
     }
@@ -332,7 +337,10 @@ mod tests {
         assert_eq!(interval.end, TestKey(Tsn(12)));
         assert!(interval.has_beginning);
         assert!(interval.has_end);
-        assert_eq!(interval.payload, &[b"p0", b"p1", b"p2"]);
+        assert_eq!(
+            interval.payload,
+            VecDeque::from([Bytes::from("p0"), Bytes::from("p1"), Bytes::from("p2")])
+        );
     }
 
     #[test]
@@ -354,7 +362,7 @@ mod tests {
         assert!(interval.has_end);
         assert!(interval.has_beginning);
         assert_eq!(interval.payload.len(), 2);
-        assert_eq!(interval.payload, &[b"p0", b"p1"]);
+        assert_eq!(interval.payload, VecDeque::from([Bytes::from("p0"), Bytes::from("p1")]));
     }
 
     #[test]

--- a/src/rx/mod.rs
+++ b/src/rx/mod.rs
@@ -119,14 +119,14 @@ impl<K: ReassemblyKey> IntervalList<K> {
 
             left.end = right.end;
             left.has_end = right.has_end;
-            left.payload.push_back(data.payload.into());
+            left.payload.push_back(data.payload);
             left.payload.append(&mut right.payload);
             idx - 1
         } else if extend_left {
             let left = &mut self.intervals[idx - 1];
             left.end = key;
             left.has_end = data.is_end;
-            left.payload.push_back(data.payload.into());
+            left.payload.push_back(data.payload);
             idx - 1
         } else if extend_right {
             let right = &mut self.intervals[idx];
@@ -137,7 +137,7 @@ impl<K: ReassemblyKey> IntervalList<K> {
             if data.is_beginning {
                 right.ppid = data.ppid;
             }
-            right.payload.push_front(data.payload.into());
+            right.payload.push_front(data.payload);
             idx
         } else {
             // No merge possible, insert new isolated interval.
@@ -149,7 +149,7 @@ impl<K: ReassemblyKey> IntervalList<K> {
                     has_beginning: data.is_beginning,
                     has_end: data.is_end,
                     ppid: data.ppid,
-                    payload: VecDeque::from([data.payload.into()]),
+                    payload: VecDeque::from([data.payload]),
                 },
             );
             idx

--- a/src/rx/reassembly_queue.rs
+++ b/src/rx/reassembly_queue.rs
@@ -275,7 +275,7 @@ mod tests {
                         stream_key: StreamKey::Unordered(StreamId(1)),
                         ssn: Ssn(0),
                         ppid: PpId(53),
-                        payload: perm_payload,
+                        payload: perm_payload.into(),
                         is_beginning,
                         is_end,
                         ..Default::default()
@@ -321,7 +321,7 @@ mod tests {
                         stream_key: StreamKey::Ordered(StreamId(1)),
                         ssn: Ssn((*tsn - 10) as u16),
                         ppid: PpId(53),
-                        payload: perm_payload,
+                        payload: perm_payload.into(),
                         is_beginning: true,
                         is_end: true,
                         ..Default::default()
@@ -517,7 +517,7 @@ mod tests {
                     Data {
                         stream_key: StreamKey::Unordered(chunk.stream_id),
                         fsn: chunk.fsn,
-                        payload: chunk.payload.as_bytes().to_vec(),
+                        payload: chunk.payload.as_bytes().to_vec().into(),
                         is_beginning: chunk.fsn == Fsn(0),
                         is_end: chunk.fsn == Fsn(2),
                         ..Default::default()

--- a/src/rx/traditional_reassembly_streams.rs
+++ b/src/rx/traditional_reassembly_streams.rs
@@ -135,7 +135,7 @@ impl UnorderedStream {
     fn add(&mut self, tsn: Tsn, data: Data, on_reassembled: &mut dyn FnMut(Message)) -> isize {
         if data.is_beginning && data.is_end {
             // Fastpath for already assembled chunks.
-            on_reassembled(Message::new(data.stream_key.id(), data.ppid, data.payload));
+            on_reassembled(Message::new(data.stream_key.id(), data.ppid, data.payload.into()));
             return 0;
         }
         let key = TraditionalKey { ssn: Ssn(0), tsn };
@@ -148,7 +148,7 @@ impl UnorderedStream {
             let payload = interval.collect_payload();
             let total_payload_len = payload.len();
 
-            on_reassembled(Message::new(stream_id, ppid, payload));
+            on_reassembled(Message::new(stream_id, ppid, payload.into()));
             queued_bytes - (total_payload_len as isize)
         } else {
             queued_bytes
@@ -207,7 +207,7 @@ impl OrderedStream {
             let payload = interval.collect_payload();
 
             assembled_bytes += payload.len();
-            on_reassembled(Message::new(stream_id, ppid, payload));
+            on_reassembled(Message::new(stream_id, ppid, payload.into()));
             self.next_ssn += 1;
         }
 
@@ -224,7 +224,7 @@ impl OrderedStream {
 
         if data.ssn == self.next_ssn && data.is_beginning && data.is_end {
             // Fastpath for already assembled chunks.
-            on_reassembled(Message::new(self.stream_id, data.ppid, data.payload));
+            on_reassembled(Message::new(self.stream_id, data.ppid, data.payload.into()));
             self.next_ssn += 1;
             let assembled = self.try_to_assemble_messages(on_reassembled);
             return -(assembled as isize);

--- a/src/rx/traditional_reassembly_streams.rs
+++ b/src/rx/traditional_reassembly_streams.rs
@@ -142,13 +142,14 @@ impl UnorderedStream {
         let queued_bytes = data.payload.len() as isize;
         let idx = self.intervals.add(key, data);
 
-        if let Some(interval) = self.intervals.pop_if_complete(idx) {
+        let complete_interval = self.intervals.pop_if_complete(idx);
+        if let Some(interval) = complete_interval {
             let stream_id = self.stream_id;
             let ppid = interval.ppid;
             let payload = interval.collect_payload();
             let total_payload_len = payload.len();
 
-            on_reassembled(Message::new(stream_id, ppid, payload.into()));
+            on_reassembled(Message::new(stream_id, ppid, payload));
             queued_bytes - (total_payload_len as isize)
         } else {
             queued_bytes
@@ -207,7 +208,7 @@ impl OrderedStream {
             let payload = interval.collect_payload();
 
             assembled_bytes += payload.len();
-            on_reassembled(Message::new(stream_id, ppid, payload.into()));
+            on_reassembled(Message::new(stream_id, ppid, payload));
             self.next_ssn += 1;
         }
 

--- a/src/rx/traditional_reassembly_streams.rs
+++ b/src/rx/traditional_reassembly_streams.rs
@@ -135,7 +135,7 @@ impl UnorderedStream {
     fn add(&mut self, tsn: Tsn, data: Data, on_reassembled: &mut dyn FnMut(Message)) -> isize {
         if data.is_beginning && data.is_end {
             // Fastpath for already assembled chunks.
-            on_reassembled(Message::new(data.stream_key.id(), data.ppid, data.payload.into()));
+            on_reassembled(Message::new(data.stream_key.id(), data.ppid, data.payload));
             return 0;
         }
         let key = TraditionalKey { ssn: Ssn(0), tsn };
@@ -225,7 +225,7 @@ impl OrderedStream {
 
         if data.ssn == self.next_ssn && data.is_beginning && data.is_end {
             // Fastpath for already assembled chunks.
-            on_reassembled(Message::new(self.stream_id, data.ppid, data.payload.into()));
+            on_reassembled(Message::new(self.stream_id, data.ppid, data.payload));
             self.next_ssn += 1;
             let assembled = self.try_to_assemble_messages(on_reassembled);
             return -(assembled as isize);

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -83,6 +83,7 @@ use crate::timer::BackoffAlgorithm;
 use crate::timer::Timer;
 use crate::tx::send_queue::SendQueue;
 use crate::types::Tsn;
+use bytes::Bytes;
 #[cfg(not(test))]
 use log::info;
 #[cfg(not(test))]
@@ -319,12 +320,12 @@ impl DcSctpSocket for Socket {
         do_connect(&mut self.state, &mut self.ctx, now);
     }
 
-    fn handle_input(&mut self, packet: &[u8]) {
+    fn handle_input(&mut self, packet: Bytes) {
         self.ctx.rx_packets_count += 1;
         let now = *self.now.borrow();
-        log_packet(&self.name, now, false, packet);
+        log_packet(&self.name, now, false, &packet);
 
-        match SctpPacket::from_bytes(packet, &self.ctx.options) {
+        match SctpPacket::from_bytes(&packet, &self.ctx.options) {
             Err(_e) => {
                 self.ctx.events.borrow_mut().add(SocketEvent::OnError(
                     ErrorKind::ParseFailed,

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -325,7 +325,7 @@ impl DcSctpSocket for Socket {
         let now = *self.now.borrow();
         log_packet(&self.name, now, false, &packet);
 
-        match SctpPacket::from_bytes(&packet, &self.ctx.options) {
+        match SctpPacket::from_bytes(packet, &self.ctx.options) {
             Err(_e) => {
                 self.ctx.events.borrow_mut().add(SocketEvent::OnError(
                     ErrorKind::ParseFailed,

--- a/src/socket/socket_tests.rs
+++ b/src/socket/socket_tests.rs
@@ -337,7 +337,7 @@ mod tests {
         // A <- INIT_ACK <- Z
         let packet = &expect_sent_packet!(socket_z.poll_event());
         let Chunk::InitAck(init_ack) =
-            SctpPacket::from_bytes(packet, &options).unwrap().chunks.pop().unwrap()
+            SctpPacket::from_bytes(packet.clone(), &options).unwrap().chunks.pop().unwrap()
         else {
             unreachable!()
         };
@@ -359,7 +359,7 @@ mod tests {
         socket_a.handle_input(packet);
 
         assert!(matches!(
-            SctpPacket::from_bytes(&expect_sent_packet!(socket_a.poll_event()), &options)
+            SctpPacket::from_bytes(expect_sent_packet!(socket_a.poll_event()), &options)
                 .unwrap()
                 .chunks[0],
             Chunk::Abort(_)
@@ -550,7 +550,7 @@ mod tests {
 
         // A -> COOKIE_ECHO ->/lost/ Z
         let packet = expect_sent_packet!(socket_a.poll_event());
-        let packet = SctpPacket::from_bytes(&packet, &options).unwrap();
+        let packet = SctpPacket::from_bytes(packet.clone(), &options).unwrap();
         assert!(matches!(packet.chunks[0], Chunk::CookieEcho(_)));
         assert!(matches!(packet.chunks[1], Chunk::Data(_)));
         expect_no_event!(socket_a.poll_event());
@@ -568,7 +568,7 @@ mod tests {
         now = now + options.t1_cookie_timeout - options.rto_initial;
         socket_a.advance_time(now);
         let packet = expect_sent_packet!(socket_a.poll_event());
-        let packet = SctpPacket::from_bytes(&packet, &options).unwrap();
+        let packet = SctpPacket::from_bytes(packet.clone(), &options).unwrap();
         assert!(matches!(packet.chunks[0], Chunk::CookieEcho(_)));
         assert!(matches!(packet.chunks[1], Chunk::Data(_)));
         expect_no_event!(socket_a.poll_event());
@@ -637,7 +637,7 @@ mod tests {
             socket_a.advance_time(now);
 
             let packet = expect_sent_packet!(socket_a.poll_event());
-            let packet = SctpPacket::from_bytes(&packet, &options).unwrap();
+            let packet = SctpPacket::from_bytes(packet.clone(), &options).unwrap();
             assert!(matches!(packet.chunks[0], Chunk::Shutdown(_)));
             expect_no_event!(socket_a.poll_event());
         }
@@ -649,7 +649,7 @@ mod tests {
         assert_eq!(socket_a.state(), SocketState::Closed);
 
         assert!(matches!(
-            SctpPacket::from_bytes(&expect_sent_packet!(socket_a.poll_event()), &options)
+            SctpPacket::from_bytes(expect_sent_packet!(socket_a.poll_event()), &options)
                 .unwrap()
                 .chunks[0],
             Chunk::Abort(_)
@@ -673,7 +673,7 @@ mod tests {
 
         // A -> SHUTDOWN_ACK -> /lost/ Z
         let packet = expect_sent_packet!(socket_a.poll_event());
-        let packet = SctpPacket::from_bytes(&packet, &options).unwrap();
+        let packet = SctpPacket::from_bytes(packet, &options).unwrap();
         assert!(matches!(packet.chunks[0], Chunk::ShutdownAck(_)));
 
         assert_eq!(socket_a.state(), SocketState::ShuttingDown);
@@ -685,7 +685,7 @@ mod tests {
 
         // A should resend SHUTDOWN_ACK.
         let packet = expect_sent_packet!(socket_a.poll_event());
-        let packet = SctpPacket::from_bytes(&packet, &options).unwrap();
+        let packet = SctpPacket::from_bytes(packet, &options).unwrap();
         assert!(matches!(packet.chunks[0], Chunk::ShutdownAck(_)));
     }
 
@@ -705,7 +705,7 @@ mod tests {
 
         // A -> SHUTDOWN_ACK -> /lost/ Z
         let packet = expect_sent_packet!(socket_a.poll_event());
-        let packet = SctpPacket::from_bytes(&packet, &options).unwrap();
+        let packet = SctpPacket::from_bytes(packet, &options).unwrap();
         assert!(matches!(packet.chunks[0], Chunk::ShutdownAck(_)));
 
         assert_eq!(socket_a.state(), SocketState::ShuttingDown);
@@ -721,7 +721,7 @@ mod tests {
 
         // A immediately resends SHUTDOWN_ACK.
         let packet = expect_sent_packet!(socket_a.poll_event());
-        let packet = SctpPacket::from_bytes(&packet, &options).unwrap();
+        let packet = SctpPacket::from_bytes(packet, &options).unwrap();
         assert!(matches!(packet.chunks[0], Chunk::ShutdownAck(_)));
     }
 
@@ -739,7 +739,7 @@ mod tests {
 
         // A produces SHUTDOWN ACK
         let packet = expect_sent_packet!(socket_a.poll_event());
-        let packet = SctpPacket::from_bytes(&packet, &options).unwrap();
+        let packet = SctpPacket::from_bytes(packet, &options).unwrap();
         assert!(matches!(packet.chunks[0], Chunk::ShutdownAck(_)));
 
         assert_eq!(socket_a.state(), SocketState::ShuttingDown);
@@ -762,7 +762,7 @@ mod tests {
         socket_a.shutdown();
 
         let packet = expect_sent_packet!(socket_a.poll_event());
-        let packet = SctpPacket::from_bytes(&packet, &options).unwrap();
+        let packet = SctpPacket::from_bytes(packet, &options).unwrap();
         assert!(matches!(packet.chunks[0], Chunk::Data(_)));
 
         assert_eq!(socket_a.state(), SocketState::ShuttingDown);
@@ -904,7 +904,7 @@ mod tests {
         .build();
         socket_a.handle_input(packet);
         let packet =
-            SctpPacket::from_bytes(&expect_sent_packet!(socket_a.poll_event()), &options).unwrap();
+            SctpPacket::from_bytes(expect_sent_packet!(socket_a.poll_event()), &options).unwrap();
         assert_eq!(packet.chunks.len(), 1);
         let Chunk::HeartbeatAck(ack) = &packet.chunks[0] else {
             panic!();
@@ -931,14 +931,14 @@ mod tests {
         assert_eq!(socket_a.poll_timeout(), expected_timeout);
         socket_a.advance_time(expected_timeout);
         let request_packet = expect_sent_packet!(socket_a.poll_event());
-        let packet = SctpPacket::from_bytes(&request_packet, &options).unwrap();
+        let packet = SctpPacket::from_bytes(request_packet.clone(), &options).unwrap();
         assert_eq!(packet.chunks.len(), 1);
         assert!(matches!(packet.chunks[0], Chunk::HeartbeatRequest { .. }));
 
         // Feed it to Sock-z and expect a HEARTBEAT_ACK that will be propagated back.
         socket_z.handle_input(request_packet);
         let ack_packet = expect_sent_packet!(socket_z.poll_event());
-        let packet = SctpPacket::from_bytes(&ack_packet, &options).unwrap();
+        let packet = SctpPacket::from_bytes(ack_packet.clone(), &options).unwrap();
         assert_eq!(packet.chunks.len(), 1);
         assert!(matches!(packet.chunks[0], Chunk::HeartbeatAck { .. }));
 
@@ -977,7 +977,7 @@ mod tests {
 
         socket_a.advance_time(restarted_heartbeat_timeout);
         let request_packet = expect_sent_packet!(socket_a.poll_event());
-        let packet = SctpPacket::from_bytes(&request_packet, &options).unwrap();
+        let packet = SctpPacket::from_bytes(request_packet.clone(), &options).unwrap();
         assert_eq!(packet.chunks.len(), 1);
         assert!(matches!(packet.chunks[0], Chunk::HeartbeatRequest { .. }));
     }
@@ -996,7 +996,7 @@ mod tests {
         now = now + options.heartbeat_interval;
         socket_a.advance_time(now);
         let hb_packet = expect_sent_packet!(socket_a.poll_event());
-        let hb_packet = SctpPacket::from_bytes(&hb_packet, &options).unwrap();
+        let hb_packet = SctpPacket::from_bytes(hb_packet.clone(), &options).unwrap();
         assert!(matches!(hb_packet.chunks[0], Chunk::HeartbeatRequest(_)));
 
         // Letting the heartbeat expire
@@ -1004,7 +1004,7 @@ mod tests {
         socket_a.advance_time(now);
 
         let abort_packet = expect_sent_packet!(socket_a.poll_event());
-        let abort_packet = SctpPacket::from_bytes(&abort_packet, &options).unwrap();
+        let abort_packet = SctpPacket::from_bytes(abort_packet.clone(), &options).unwrap();
         assert!(matches!(abort_packet.chunks[0], Chunk::Abort(_)));
 
         assert_eq!(expect_on_aborted!(socket_a.poll_event()), ErrorKind::TooManyRetries);
@@ -1025,7 +1025,7 @@ mod tests {
         now = now + options.heartbeat_interval;
         socket_a.advance_time(now);
         let hb_packet = expect_sent_packet!(socket_a.poll_event());
-        let hb_packet = SctpPacket::from_bytes(&hb_packet, &options).unwrap();
+        let hb_packet = SctpPacket::from_bytes(hb_packet.clone(), &options).unwrap();
         assert!(matches!(hb_packet.chunks[0], Chunk::HeartbeatRequest(_)));
 
         // Letting the heartbeat expire
@@ -1036,7 +1036,7 @@ mod tests {
         now = now + options.heartbeat_interval - options.rto_initial;
         socket_a.advance_time(now);
         let hb_packet = expect_sent_packet!(socket_a.poll_event());
-        let hb_packet = SctpPacket::from_bytes(&hb_packet, &options).unwrap();
+        let hb_packet = SctpPacket::from_bytes(hb_packet.clone(), &options).unwrap();
         assert!(matches!(hb_packet.chunks[0], Chunk::HeartbeatRequest(_)));
 
         // Letting the heartbeat expire
@@ -1044,7 +1044,7 @@ mod tests {
         socket_a.advance_time(now);
 
         let abort_packet = expect_sent_packet!(socket_a.poll_event());
-        let abort_packet = SctpPacket::from_bytes(&abort_packet, &options).unwrap();
+        let abort_packet = SctpPacket::from_bytes(abort_packet.clone(), &options).unwrap();
         assert!(matches!(abort_packet.chunks[0], Chunk::Abort(_)));
 
         assert_eq!(expect_on_aborted!(socket_a.poll_event()), ErrorKind::TooManyRetries);
@@ -1071,7 +1071,7 @@ mod tests {
 
             // Dropping every heartbeat.
             let hb_packet = expect_sent_packet!(socket_a.poll_event());
-            let hb_packet = SctpPacket::from_bytes(&hb_packet, &options).unwrap();
+            let hb_packet = SctpPacket::from_bytes(hb_packet.clone(), &options).unwrap();
             assert!(matches!(hb_packet.chunks[0], Chunk::HeartbeatRequest(_)));
 
             // Letting the heartbeat expire
@@ -1087,14 +1087,14 @@ mod tests {
 
         // Last heartbeat
         let hb_packet = expect_sent_packet!(socket_a.poll_event());
-        let hb_packet = SctpPacket::from_bytes(&hb_packet, &options).unwrap();
+        let hb_packet = SctpPacket::from_bytes(hb_packet.clone(), &options).unwrap();
         assert!(matches!(hb_packet.chunks[0], Chunk::HeartbeatRequest(_)));
 
         now = now + Duration::from_secs(1);
         socket_a.advance_time(now);
 
         let abort_packet = expect_sent_packet!(socket_a.poll_event());
-        let abort_packet = SctpPacket::from_bytes(&abort_packet, &options).unwrap();
+        let abort_packet = SctpPacket::from_bytes(abort_packet.clone(), &options).unwrap();
         assert!(matches!(abort_packet.chunks[0], Chunk::Abort(_)));
 
         assert_eq!(expect_on_aborted!(socket_a.poll_event()), ErrorKind::TooManyRetries);
@@ -1120,7 +1120,7 @@ mod tests {
 
             // Dropping every heartbeat.
             let hb_packet = expect_sent_packet!(socket_a.poll_event());
-            let hb_packet = SctpPacket::from_bytes(&hb_packet, &options).unwrap();
+            let hb_packet = SctpPacket::from_bytes(hb_packet.clone(), &options).unwrap();
             assert!(matches!(hb_packet.chunks[0], Chunk::HeartbeatRequest(_)));
 
             // Letting the heartbeat expire
@@ -1136,7 +1136,7 @@ mod tests {
 
         // Last heartbeat
         let hb_packet = expect_sent_packet!(socket_a.poll_event());
-        let mut hb_packet = SctpPacket::from_bytes(&hb_packet, &options).unwrap();
+        let mut hb_packet = SctpPacket::from_bytes(hb_packet.clone(), &options).unwrap();
         let Some(Chunk::HeartbeatRequest(req)) = hb_packet.chunks.pop() else {
             panic!();
         };
@@ -1162,7 +1162,7 @@ mod tests {
         socket_a.advance_time(now);
 
         let hb_packet = expect_sent_packet!(socket_a.poll_event());
-        let hb_packet = SctpPacket::from_bytes(&hb_packet, &options).unwrap();
+        let hb_packet = SctpPacket::from_bytes(hb_packet.clone(), &options).unwrap();
         assert!(matches!(hb_packet.chunks[0], Chunk::HeartbeatRequest(_)));
     }
 
@@ -1182,7 +1182,7 @@ mod tests {
 
         let hb_packet = expect_sent_packet!(socket_a.poll_event());
         assert!(matches!(
-            SctpPacket::from_bytes(&hb_packet, &options).unwrap().chunks[0],
+            SctpPacket::from_bytes(hb_packet.clone(), &options).unwrap().chunks[0],
             Chunk::HeartbeatRequest(_)
         ));
 
@@ -1194,7 +1194,7 @@ mod tests {
         socket_a.advance_time(now);
 
         let hb_packet = expect_sent_packet!(socket_a.poll_event());
-        let mut hb_packet = SctpPacket::from_bytes(&hb_packet, &options).unwrap();
+        let mut hb_packet = SctpPacket::from_bytes(hb_packet.clone(), &options).unwrap();
         let Some(Chunk::HeartbeatRequest(req)) = hb_packet.chunks.pop() else {
             panic!();
         };
@@ -1215,7 +1215,7 @@ mod tests {
 
         let hb_packet = expect_sent_packet!(socket_a.poll_event());
         assert!(matches!(
-            SctpPacket::from_bytes(&hb_packet, &options).unwrap().chunks[0],
+            SctpPacket::from_bytes(hb_packet.clone(), &options).unwrap().chunks[0],
             Chunk::HeartbeatRequest(_)
         ));
 
@@ -1366,7 +1366,7 @@ mod tests {
         socket_a.send(Message::new(StreamId(3), PpId(53), payload.clone()), &s).unwrap();
 
         let packet =
-            SctpPacket::from_bytes(&expect_sent_packet!(socket_a.poll_event()), &options).unwrap();
+            SctpPacket::from_bytes(expect_sent_packet!(socket_a.poll_event()), &options).unwrap();
         assert_eq!(packet.chunks.len(), 1);
         let Chunk::Data(chunk) = &packet.chunks[0] else {
             panic!();
@@ -1375,7 +1375,7 @@ mod tests {
         assert_eq!(chunk.data.ssn, Ssn(2));
 
         let packet =
-            SctpPacket::from_bytes(&expect_sent_packet!(socket_a.poll_event()), &options).unwrap();
+            SctpPacket::from_bytes(expect_sent_packet!(socket_a.poll_event()), &options).unwrap();
         assert_eq!(packet.chunks.len(), 1);
         let Chunk::Data(chunk) = &packet.chunks[0] else {
             panic!();
@@ -1495,7 +1495,7 @@ mod tests {
 
         // Dropping first transmission.
         let packet = expect_sent_packet!(socket_a.poll_event());
-        let packet = SctpPacket::from_bytes(&packet, &options).unwrap();
+        let packet = SctpPacket::from_bytes(packet, &options).unwrap();
         assert!(matches!(packet.chunks[0], Chunk::Data(_)));
 
         // Letting it expire.
@@ -1503,7 +1503,7 @@ mod tests {
         socket_a.advance_time(now);
 
         let packet = expect_sent_packet!(socket_a.poll_event());
-        let packet = SctpPacket::from_bytes(&packet, &options).unwrap();
+        let packet = SctpPacket::from_bytes(packet.clone(), &options).unwrap();
         assert!(matches!(packet.chunks[0], Chunk::Abort(_)));
 
         assert_eq!(expect_on_aborted!(socket_a.poll_event()), ErrorKind::TooManyRetries);
@@ -1522,7 +1522,7 @@ mod tests {
         socket_a.send(Message::with_size(2), &SendOptions::default()).unwrap();
         // Dropping first transmission.
         let packet = expect_sent_packet!(socket_a.poll_event());
-        let packet = SctpPacket::from_bytes(&packet, &options).unwrap();
+        let packet = SctpPacket::from_bytes(packet.clone(), &options).unwrap();
         assert!(matches!(packet.chunks[0], Chunk::Data(_)));
 
         // Dropping the one allowed re-transmission.
@@ -1530,14 +1530,14 @@ mod tests {
         socket_a.advance_time(now);
 
         let packet = expect_sent_packet!(socket_a.poll_event());
-        let packet = SctpPacket::from_bytes(&packet, &options).unwrap();
+        let packet = SctpPacket::from_bytes(packet.clone(), &options).unwrap();
         assert!(matches!(packet.chunks[0], Chunk::Data(_)));
 
         now = now + options.rto_initial * 2;
         socket_a.advance_time(now);
 
         let packet = expect_sent_packet!(socket_a.poll_event());
-        let packet = SctpPacket::from_bytes(&packet, &options).unwrap();
+        let packet = SctpPacket::from_bytes(packet.clone(), &options).unwrap();
         assert!(matches!(packet.chunks[0], Chunk::Abort(_)));
 
         assert_eq!(expect_on_aborted!(socket_a.poll_event()), ErrorKind::TooManyRetries);
@@ -1556,7 +1556,7 @@ mod tests {
         socket_a.send(Message::with_size(2), &SendOptions::default()).unwrap();
         // Dropping first transmission.
         let packet = expect_sent_packet!(socket_a.poll_event());
-        let packet = SctpPacket::from_bytes(&packet, &options).unwrap();
+        let packet = SctpPacket::from_bytes(packet.clone(), &options).unwrap();
         assert!(matches!(packet.chunks[0], Chunk::Data(_)));
 
         // Acking the retransmission
@@ -1565,7 +1565,7 @@ mod tests {
 
         let packet = expect_sent_packet!(socket_a.poll_event());
         assert!(matches!(
-            SctpPacket::from_bytes(&packet, &options).unwrap().chunks[0],
+            SctpPacket::from_bytes(packet.clone(), &options).unwrap().chunks[0],
             Chunk::Data(_)
         ));
         socket_z.handle_input(packet);
@@ -1573,7 +1573,7 @@ mod tests {
 
         let packet = expect_sent_packet!(socket_z.poll_event());
         assert!(matches!(
-            SctpPacket::from_bytes(&packet, &options).unwrap().chunks[0],
+            SctpPacket::from_bytes(packet.clone(), &options).unwrap().chunks[0],
             Chunk::Sack(_)
         ));
         socket_a.handle_input(packet);
@@ -1583,7 +1583,7 @@ mod tests {
 
         // Dropping first transmission of second message. The TX error counter recovered before.
         let packet = expect_sent_packet!(socket_a.poll_event());
-        let packet = SctpPacket::from_bytes(&packet, &options).unwrap();
+        let packet = SctpPacket::from_bytes(packet.clone(), &options).unwrap();
         assert!(matches!(packet.chunks[0], Chunk::Data(_)));
 
         now = now + options.rto_initial;
@@ -1592,7 +1592,7 @@ mod tests {
         // The socket should not abort, but retransmit the packet.
         let packet = expect_sent_packet!(socket_a.poll_event());
         assert!(matches!(
-            SctpPacket::from_bytes(&packet, &options).unwrap().chunks[0],
+            SctpPacket::from_bytes(packet.clone(), &options).unwrap().chunks[0],
             Chunk::Data(_)
         ));
         expect_no_event!(socket_a.poll_event());
@@ -1619,7 +1619,7 @@ mod tests {
         expect_no_event!(socket_a.poll_event());
         expect_no_event!(socket_z.poll_event());
         assert!(matches!(
-            SctpPacket::from_bytes(&packet, &options_a).unwrap().chunks[0],
+            SctpPacket::from_bytes(packet.clone(), &options_a).unwrap().chunks[0],
             Chunk::HeartbeatRequest(_)
         ));
 
@@ -1633,7 +1633,7 @@ mod tests {
         expect_no_event!(socket_a.poll_event());
         expect_no_event!(socket_z.poll_event());
         assert!(matches!(
-            SctpPacket::from_bytes(&packet, &options_a).unwrap().chunks[0],
+            SctpPacket::from_bytes(packet.clone(), &options_a).unwrap().chunks[0],
             Chunk::HeartbeatRequest(_)
         ));
     }
@@ -1650,7 +1650,7 @@ mod tests {
         socket_a.send(Message::with_size(2), &SendOptions::default()).unwrap();
         // Dropping first transmission.
         let packet = expect_sent_packet!(socket_a.poll_event());
-        let packet = SctpPacket::from_bytes(&packet, &options).unwrap();
+        let packet = SctpPacket::from_bytes(packet.clone(), &options).unwrap();
         assert!(matches!(packet.chunks[0], Chunk::Data(_)));
 
         for i in 0..options.max_retransmissions.unwrap() {
@@ -1659,7 +1659,7 @@ mod tests {
             socket_a.advance_time(now);
 
             let packet = expect_sent_packet!(socket_a.poll_event());
-            let packet = SctpPacket::from_bytes(&packet, &options).unwrap();
+            let packet = SctpPacket::from_bytes(packet.clone(), &options).unwrap();
             assert!(matches!(packet.chunks[0], Chunk::Data(_)));
         }
 
@@ -1670,7 +1670,7 @@ mod tests {
         println!("Done");
 
         let packet = expect_sent_packet!(socket_a.poll_event());
-        let packet = SctpPacket::from_bytes(&packet, &options).unwrap();
+        let packet = SctpPacket::from_bytes(packet.clone(), &options).unwrap();
         assert!(matches!(packet.chunks[0], Chunk::Abort(_)));
 
         assert_eq!(expect_on_aborted!(socket_a.poll_event()), ErrorKind::TooManyRetries);
@@ -1689,7 +1689,7 @@ mod tests {
         socket_a.send(Message::with_size(2), &SendOptions::default()).unwrap();
         // Dropping first transmission.
         let packet = expect_sent_packet!(socket_a.poll_event());
-        let packet = SctpPacket::from_bytes(&packet, &options).unwrap();
+        let packet = SctpPacket::from_bytes(packet.clone(), &options).unwrap();
         assert!(matches!(packet.chunks[0], Chunk::Data(_)));
 
         for i in 0..options.max_retransmissions.unwrap() - 1 {
@@ -1698,7 +1698,7 @@ mod tests {
             socket_a.advance_time(now);
 
             let packet = expect_sent_packet!(socket_a.poll_event());
-            let packet = SctpPacket::from_bytes(&packet, &options).unwrap();
+            let packet = SctpPacket::from_bytes(packet.clone(), &options).unwrap();
             assert!(matches!(packet.chunks[0], Chunk::Data(_)));
         }
 
@@ -2934,22 +2934,22 @@ mod tests {
 
         let data1 = expect_sent_packet!(socket_a.poll_event());
         assert!(matches!(
-            SctpPacket::from_bytes(&data1, &options).unwrap().chunks[0],
+            SctpPacket::from_bytes(data1.clone(), &options).unwrap().chunks[0],
             Chunk::Data(DataChunk { data: Data { ssn: Ssn(0), .. }, .. })
         ));
         let data2 = expect_sent_packet!(socket_a.poll_event());
         assert!(matches!(
-            SctpPacket::from_bytes(&data2, &options).unwrap().chunks[0],
+            SctpPacket::from_bytes(data2.clone(), &options).unwrap().chunks[0],
             Chunk::Data(DataChunk { data: Data { ssn: Ssn(0), .. }, .. })
         ));
         let data3 = expect_sent_packet!(socket_a.poll_event());
         assert!(matches!(
-            SctpPacket::from_bytes(&data3, &options).unwrap().chunks[0],
+            SctpPacket::from_bytes(data3.clone(), &options).unwrap().chunks[0],
             Chunk::Data(DataChunk { data: Data { ssn: Ssn(1), .. }, .. })
         ));
         let reconfig = expect_sent_packet!(socket_a.poll_event());
         assert!(matches!(
-            SctpPacket::from_bytes(&reconfig, &options).unwrap().chunks[0],
+            SctpPacket::from_bytes(reconfig.clone(), &options).unwrap().chunks[0],
             Chunk::ReConfig(_)
         ));
 
@@ -2973,7 +2973,7 @@ mod tests {
 
         let packet = expect_sent_packet!(socket_a.poll_event());
         assert!(matches!(
-            SctpPacket::from_bytes(&packet, &options).unwrap().chunks[0],
+            SctpPacket::from_bytes(packet.clone(), &options).unwrap().chunks[0],
             Chunk::ReConfig(_)
         ));
         socket_z.handle_input(packet);
@@ -2982,7 +2982,7 @@ mod tests {
 
         let packet = expect_sent_packet!(socket_z.poll_event());
         assert!(matches!(
-            SctpPacket::from_bytes(&packet, &options).unwrap().chunks[0],
+            SctpPacket::from_bytes(packet.clone(), &options).unwrap().chunks[0],
             Chunk::ReConfig(_)
         ));
         socket_a.handle_input(packet);
@@ -3069,7 +3069,7 @@ mod tests {
         socket_a.connect();
         // A -> INIT -> Z
         let packet = expect_sent_packet!(socket_a.poll_event());
-        let packet = SctpPacket::from_bytes(&packet, &options).unwrap();
+        let packet = SctpPacket::from_bytes(packet.clone(), &options).unwrap();
         assert_ne!(packet.common_header.checksum, 0);
     }
 
@@ -3088,7 +3088,7 @@ mod tests {
 
         // A <- INIT_ACK <- Z
         let packet = expect_sent_packet!(socket_z.poll_event());
-        let packet = SctpPacket::from_bytes(&packet, &options).unwrap();
+        let packet = SctpPacket::from_bytes(packet.clone(), &options).unwrap();
         assert_eq!(packet.common_header.checksum, 0);
     }
 
@@ -3109,7 +3109,7 @@ mod tests {
 
         // A -> COOKIE_ECHO -> Z
         let packet = expect_sent_packet!(socket_a.poll_event());
-        let packet = SctpPacket::from_bytes(&packet, &options).unwrap();
+        let packet = SctpPacket::from_bytes(packet.clone(), &options).unwrap();
         assert_ne!(packet.common_header.checksum, 0);
     }
 
@@ -3133,7 +3133,7 @@ mod tests {
 
         // A <- COOOKIE_ACK <- Z
         let packet = expect_sent_packet!(socket_z.poll_event());
-        let packet = SctpPacket::from_bytes(&packet, &options).unwrap();
+        let packet = SctpPacket::from_bytes(packet.clone(), &options).unwrap();
         assert_eq!(packet.common_header.checksum, 0);
     }
 
@@ -3151,7 +3151,7 @@ mod tests {
         socket_a.send(Message::with_size(2), &SendOptions::default()).unwrap();
 
         let packet = expect_sent_packet!(socket_a.poll_event());
-        let packet = SctpPacket::from_bytes(&packet, &options).unwrap();
+        let packet = SctpPacket::from_bytes(packet.clone(), &options).unwrap();
         assert_eq!(packet.common_header.checksum, 0);
     }
 
@@ -3173,7 +3173,7 @@ mod tests {
         loop {
             if let Some(e) = socket_a.poll_event() {
                 if let SocketEvent::SendPacket(send) = e {
-                    let packet = SctpPacket::from_bytes(&send, &options).unwrap();
+                    let packet = SctpPacket::from_bytes(send.clone(), &options).unwrap();
                     assert_eq!(packet.common_header.checksum, 0);
                     socket_z.handle_input(send);
                 }
@@ -3181,7 +3181,7 @@ mod tests {
             }
             if let Some(e) = socket_z.poll_event() {
                 if let SocketEvent::SendPacket(send) = e {
-                    let packet = SctpPacket::from_bytes(&send, &options).unwrap();
+                    let packet = SctpPacket::from_bytes(send.clone(), &options).unwrap();
                     assert_eq!(packet.common_header.checksum, 0);
                     socket_a.handle_input(send);
                 }
@@ -3215,7 +3215,7 @@ mod tests {
 
         let fwd_tsn_packet = expect_sent_packet!(socket_a.poll_event());
         assert!(matches!(
-            SctpPacket::from_bytes(&fwd_tsn_packet, &options).unwrap().chunks[0],
+            SctpPacket::from_bytes(fwd_tsn_packet.clone(), &options).unwrap().chunks[0],
             Chunk::ForwardTsn(_)
         ));
 
@@ -3223,7 +3223,7 @@ mod tests {
         socket_a.reset_streams(&[StreamId(1)]).unwrap();
         let reconfig_packet = expect_sent_packet!(socket_a.poll_event());
         assert!(matches!(
-            SctpPacket::from_bytes(&reconfig_packet, &options).unwrap().chunks[0],
+            SctpPacket::from_bytes(reconfig_packet.clone(), &options).unwrap().chunks[0],
             Chunk::ReConfig(_)
         ));
 
@@ -3242,7 +3242,7 @@ mod tests {
 
         let data_packet = expect_sent_packet!(socket_a.poll_event());
         socket_z.handle_input(data_packet.clone());
-        let data_packet = SctpPacket::from_bytes(&data_packet, &options).unwrap();
+        let data_packet = SctpPacket::from_bytes(data_packet.clone(), &options).unwrap();
         let Chunk::Data(c) = &data_packet.chunks[0] else {
             panic!();
         };
@@ -3251,7 +3251,7 @@ mod tests {
 
         let data_packet = expect_sent_packet!(socket_a.poll_event());
         socket_z.handle_input(data_packet.clone());
-        let data_packet = SctpPacket::from_bytes(&data_packet, &options).unwrap();
+        let data_packet = SctpPacket::from_bytes(data_packet.clone(), &options).unwrap();
         let Chunk::Data(c) = &data_packet.chunks[0] else {
             panic!();
         };
@@ -3281,8 +3281,8 @@ mod tests {
         let packet2 = expect_sent_packet!(socket_a.poll_event());
         expect_no_event!(socket_a.poll_event());
 
-        let packet1 = SctpPacket::from_bytes(&packet1, &options).unwrap();
-        let packet2 = SctpPacket::from_bytes(&packet2, &options).unwrap();
+        let packet1 = SctpPacket::from_bytes(packet1.clone(), &options).unwrap();
+        let packet2 = SctpPacket::from_bytes(packet2.clone(), &options).unwrap();
 
         let Chunk::Init(init1) = &packet1.chunks[0] else { unreachable!() };
         let Chunk::Init(init2) = &packet2.chunks[0] else { unreachable!() };
@@ -3310,8 +3310,8 @@ mod tests {
         let init_ack_packet2 = expect_sent_packet!(socket_z.poll_event());
         expect_no_event!(socket_z.poll_event());
 
-        let packet1 = SctpPacket::from_bytes(&init_ack_packet1, &options).unwrap();
-        let packet2 = SctpPacket::from_bytes(&init_ack_packet2, &options).unwrap();
+        let packet1 = SctpPacket::from_bytes(init_ack_packet1.clone(), &options).unwrap();
+        let packet2 = SctpPacket::from_bytes(init_ack_packet2.clone(), &options).unwrap();
 
         let Chunk::InitAck(init_ack1) = &packet1.chunks[0] else { unreachable!() };
         let Chunk::InitAck(init_ack2) = &packet2.chunks[0] else { unreachable!() };
@@ -3483,7 +3483,7 @@ mod tests {
         // A -> COOKIE_ECHO + DATA.
         let packet_a_cookie_echo = expect_sent_packet!(socket_a.poll_event());
         // Verify it contains DATA
-        let packet = SctpPacket::from_bytes(&packet_a_cookie_echo, &options).unwrap();
+        let packet = SctpPacket::from_bytes(packet_a_cookie_echo.clone(), &options).unwrap();
         assert!(packet.chunks.iter().any(|c| matches!(c, Chunk::Data(_))));
 
         // DROP packet_a_cookie_echo. Z does not receive it.
@@ -3510,7 +3510,7 @@ mod tests {
 
         // A -> DATA (Retransmission)
         let packet_retransmit = expect_sent_packet!(socket_a.poll_event());
-        let packet = SctpPacket::from_bytes(&packet_retransmit, &options).unwrap();
+        let packet = SctpPacket::from_bytes(packet_retransmit.clone(), &options).unwrap();
         assert!(packet.chunks.iter().any(|c| matches!(c, Chunk::Data(_))));
 
         // Z <- DATA
@@ -3537,7 +3537,7 @@ mod tests {
         socket_z.handle_input(packet);
 
         let packet = expect_sent_packet!(socket_z.poll_event());
-        let packet = SctpPacket::from_bytes(&packet, &options).unwrap();
+        let packet = SctpPacket::from_bytes(packet.clone(), &options).unwrap();
         assert!(packet.chunks.iter().any(|c| matches!(c, Chunk::Sack(_))));
 
         // Send a second message from A to Z. This will be the second packet, which should trigger
@@ -3558,7 +3558,7 @@ mod tests {
         // Advancing time by the SACK timeout should however trigger it to send.
         socket_z.advance_time(next_timeout);
         let packet = expect_sent_packet!(socket_z.poll_event());
-        let packet = SctpPacket::from_bytes(&packet, &options).unwrap();
+        let packet = SctpPacket::from_bytes(packet.clone(), &options).unwrap();
         assert!(packet.chunks.iter().any(|c| matches!(c, Chunk::Sack(_))));
     }
 }

--- a/src/socket/socket_tests.rs
+++ b/src/socket/socket_tests.rs
@@ -66,6 +66,7 @@ mod tests {
     use crate::testing::event_helpers::is_lifecycle_message_maybe_expired;
     use crate::types::Ssn;
     use crate::types::StreamKey;
+    use bytes::Bytes;
     use core::panic;
     use std::cmp::min;
     use std::collections::HashSet;
@@ -94,13 +95,13 @@ mod tests {
         }
     }
 
-    fn zeroed_bytes(size: usize) -> Vec<u8> {
-        vec![0; size]
+    fn zeroed_bytes(size: usize) -> Bytes {
+        Bytes::from(vec![0; size])
     }
 
     trait MessageTestExt {
         fn with_size(size: usize) -> Self;
-        fn with_payload(payload: Vec<u8>) -> Self;
+        fn with_payload(payload: Bytes) -> Self;
     }
 
     impl MessageTestExt for Message {
@@ -108,7 +109,7 @@ mod tests {
             Message::new(StreamId(1), PpId(53), zeroed_bytes(size))
         }
 
-        fn with_payload(payload: Vec<u8>) -> Self {
+        fn with_payload(payload: Bytes) -> Self {
             Message::new(StreamId(1), PpId(53), payload)
         }
     }
@@ -123,7 +124,7 @@ mod tests {
             let mut again = false;
             if let Some(e) = socket_a.poll_event() {
                 if let SocketEvent::SendPacket(send) = e {
-                    socket_z.handle_input(&send);
+                    socket_z.handle_input(send);
                 } else {
                     events_a.push_back(e);
                 }
@@ -131,7 +132,7 @@ mod tests {
             }
             if let Some(e) = socket_z.poll_event() {
                 if let SocketEvent::SendPacket(send) = e {
-                    socket_a.handle_input(&send);
+                    socket_a.handle_input(send);
                 } else {
                     events_z.push_back(e);
                 }
@@ -155,14 +156,14 @@ mod tests {
     fn connect_sockets(socket_a: &mut Socket, socket_z: &mut Socket) {
         socket_a.connect();
         // A -> INIT -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         // A <- INIT_ACK <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
         // A -> COOKIE_ECHO -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         expect_on_connected!(socket_z.poll_event());
         // A <- COOKIE_ACK <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
         expect_on_connected!(socket_a.poll_event());
         expect_no_event!(socket_a.poll_event());
         expect_no_event!(socket_z.poll_event());
@@ -199,14 +200,14 @@ mod tests {
 
         socket_a.connect();
         // A -> INIT -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         // A <- INIT_ACK <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
         // A -> COOKIE_ECHO -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         expect_on_connected!(socket_z.poll_event());
         // A <- COOKIE_ACK <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
         expect_on_connected!(socket_a.poll_event());
         expect_no_event!(socket_a.poll_event());
         expect_no_event!(socket_z.poll_event());
@@ -224,8 +225,8 @@ mod tests {
         connect_sockets(&mut socket_a, &mut socket_z);
 
         let messages = vec![
-            Message::new(StreamId(1), PpId(1), b"hello".to_vec()),
-            Message::new(StreamId(2), PpId(2), b"world".to_vec()),
+            Message::new(StreamId(1), PpId(1), Bytes::from_static(b"hello")),
+            Message::new(StreamId(2), PpId(2), Bytes::from_static(b"world")),
         ];
         socket_a.send_many(messages, &SendOptions::default()).unwrap();
 
@@ -262,11 +263,11 @@ mod tests {
         socket_a.connect();
 
         // A -> INIT -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         // A <- INIT_ACK <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
         // A -> COOKIE_ECHO -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         expect_on_connected!(socket_z.poll_event());
         // A /lost/ <- COOKIE_ACK <- Z
         expect_sent_packet!(socket_z.poll_event());
@@ -280,11 +281,11 @@ mod tests {
         socket_a.shutdown();
 
         // A -> SHUTDOWN -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         // A <- SHUTDOWN_ACK <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
         // A -> SHUTDOWN_COMPLETE -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
 
         expect_on_closed!(socket_a.poll_event());
         expect_on_closed!(socket_z.poll_event());
@@ -308,16 +309,16 @@ mod tests {
         socket_z.connect();
 
         // A <- INIT <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
         // A -> INIT_ACK -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         // A <- COOKIE_ECHO <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
         expect_on_connected!(socket_a.poll_event());
         assert_eq!(socket_a.state(), SocketState::Connected);
 
         // A -> COOKIE_ACK -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         expect_on_connected!(socket_z.poll_event());
         assert_eq!(socket_z.state(), SocketState::Connected);
 
@@ -332,7 +333,7 @@ mod tests {
         let mut socket_z = Socket::new("Z", &options);
         socket_a.connect();
         // A -> INIT -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         // A <- INIT_ACK <- Z
         let packet = &expect_sent_packet!(socket_z.poll_event());
         let Chunk::InitAck(init_ack) =
@@ -355,7 +356,7 @@ mod tests {
         )
         .add(&Chunk::InitAck(InitAckChunk { parameters, ..init_ack }))
         .build();
-        socket_a.handle_input(&packet);
+        socket_a.handle_input(packet);
 
         assert!(matches!(
             SctpPacket::from_bytes(&expect_sent_packet!(socket_a.poll_event()), &options)
@@ -374,11 +375,11 @@ mod tests {
 
         socket_a.connect();
         // A -> INIT -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         // A <- INIT_ACK <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
         // A -> COOKIE_ECHO -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         expect_on_connected!(socket_z.poll_event());
         // A /lost/<- COOKIE_ACK <- Z
         expect_sent_packet!(socket_z.poll_event());
@@ -393,9 +394,9 @@ mod tests {
         socket_a.advance_time(expected_timeout);
 
         // A -> COOKIE_ECHO -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         // A <- COOKIE_ACK <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
         expect_on_connected!(socket_a.poll_event());
         assert_eq!(socket_a.state(), SocketState::Connected);
 
@@ -420,14 +421,14 @@ mod tests {
         socket_a.advance_time(expected_timeout);
 
         // A -> INIT -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         // A <- INIT_ACK <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
         // A -> COOKIE_ECHO -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         expect_on_connected!(socket_z.poll_event());
         // A <- COOKIE_ACK <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
         expect_on_connected!(socket_a.poll_event());
 
         assert_eq!(socket_a.state(), SocketState::Connected);
@@ -471,9 +472,9 @@ mod tests {
 
         socket_a.connect();
         // A -> INIT -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         // A <- INIT_ACK <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
         // A -> COOKIE_ECHO ->/lost/ Z
         expect_sent_packet!(socket_a.poll_event());
 
@@ -487,10 +488,10 @@ mod tests {
         socket_a.advance_time(expected_timeout);
 
         // A -> COOKIE_ECHO -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         expect_on_connected!(socket_z.poll_event());
         // A <- COOKIE_ACK <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
         expect_on_connected!(socket_a.poll_event());
 
         assert_eq!(socket_a.state(), SocketState::Connected);
@@ -508,9 +509,9 @@ mod tests {
 
         socket_a.connect();
         // A -> INIT -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         // A <- INIT_ACK <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
 
         // A -> COOKIE_ECHO ->/lost/ Z
         expect_sent_packet!(socket_a.poll_event());
@@ -543,9 +544,9 @@ mod tests {
         socket_a.send(Message::with_size(payload_size), &SendOptions::default()).unwrap();
         socket_a.connect();
         // A -> INIT -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         // A <- INIT_ACK <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
 
         // A -> COOKIE_ECHO ->/lost/ Z
         let packet = expect_sent_packet!(socket_a.poll_event());
@@ -577,10 +578,10 @@ mod tests {
         socket_a.advance_time(now);
 
         // A -> COOKIE_ECHO -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         expect_on_connected!(socket_z.poll_event());
         // A <- COOKIE_ACK <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
         expect_on_connected!(socket_a.poll_event());
 
         exchange_packets(&mut socket_a, &mut socket_z);
@@ -600,11 +601,11 @@ mod tests {
         socket_a.shutdown();
 
         // A -> SHUTDOWN -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         // A <- SHUTDOWN_ACK <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
         // A -> SHUTDOWN_COMPLETE -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
 
         expect_on_closed!(socket_a.poll_event());
         expect_on_closed!(socket_z.poll_event());
@@ -668,7 +669,7 @@ mod tests {
         socket_z.shutdown();
 
         // Z -> SHUTDOWN -> A
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
 
         // A -> SHUTDOWN_ACK -> /lost/ Z
         let packet = expect_sent_packet!(socket_a.poll_event());
@@ -700,7 +701,7 @@ mod tests {
 
         // Z -> SHUTDOWN -> A
         let shutdown_packet = expect_sent_packet!(socket_z.poll_event());
-        socket_a.handle_input(&shutdown_packet);
+        socket_a.handle_input(shutdown_packet);
 
         // A -> SHUTDOWN_ACK -> /lost/ Z
         let packet = expect_sent_packet!(socket_a.poll_event());
@@ -716,7 +717,7 @@ mod tests {
 
         // Z retransmits SHUTDOWN.
         let resent_shutdown_packet = expect_sent_packet!(socket_z.poll_event());
-        socket_a.handle_input(&resent_shutdown_packet);
+        socket_a.handle_input(resent_shutdown_packet);
 
         // A immediately resends SHUTDOWN_ACK.
         let packet = expect_sent_packet!(socket_a.poll_event());
@@ -734,7 +735,7 @@ mod tests {
         socket_z.shutdown();
 
         // Z -> SHUTDOWN -> A
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
 
         // A produces SHUTDOWN ACK
         let packet = expect_sent_packet!(socket_a.poll_event());
@@ -779,18 +780,18 @@ mod tests {
 
         socket_a.connect();
         socket_a
-            .send(Message::new(StreamId(1), PpId(53), vec![1, 2]), &SendOptions::default())
+            .send(Message::with_payload(Bytes::from_static(&[1, 2])), &SendOptions::default())
             .unwrap();
 
         // A -> INIT -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         // A <- INIT_ACK <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
         // A -> COOKIE_ECHO + DATA -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         expect_on_connected!(socket_z.poll_event());
         // A <- COOKIE_ACK <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
         expect_on_connected!(socket_a.poll_event());
         assert_eq!(socket_a.state(), SocketState::Connected);
         assert_eq!(socket_z.state(), SocketState::Connected);
@@ -800,7 +801,7 @@ mod tests {
         assert_eq!(msg.payload, vec![1, 2]);
 
         // A -> SACK -> Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
 
         expect_no_event!(socket_a.poll_event());
         expect_no_event!(socket_z.poll_event());
@@ -814,16 +815,16 @@ mod tests {
         connect_sockets(&mut socket_a, &mut socket_z);
 
         socket_z
-            .send(Message::new(StreamId(1), PpId(53), vec![1, 2]), &SendOptions::default())
+            .send(Message::with_payload(Bytes::from_static(&[1, 2])), &SendOptions::default())
             .unwrap();
         // A <- DATA <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
         let msg = socket_a.get_next_message().unwrap();
         assert_eq!(msg.stream_id, StreamId(1));
         assert_eq!(msg.payload, vec![1, 2]);
 
         // A -> SACK -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
 
         expect_no_event!(socket_a.poll_event());
         expect_no_event!(socket_z.poll_event());
@@ -837,7 +838,7 @@ mod tests {
         connect_sockets(&mut socket_a, &mut socket_z);
 
         socket_z
-            .send(Message::new(StreamId(1), PpId(53), vec![1, 2]), &SendOptions::default())
+            .send(Message::with_payload(Bytes::from_static(&[1, 2])), &SendOptions::default())
             .unwrap();
         // A /lost/ <- DATA <- Z
         expect_sent_packet!(socket_z.poll_event());
@@ -845,13 +846,13 @@ mod tests {
         assert_eq!(socket_z.poll_timeout(), expected_timeout);
         socket_z.advance_time(expected_timeout);
 
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
         let msg = socket_a.get_next_message().unwrap();
         assert_eq!(msg.stream_id, StreamId(1));
         assert_eq!(msg.payload, vec![1, 2]);
 
         // A -> SACK -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
 
         expect_no_event!(socket_a.poll_event());
         expect_no_event!(socket_z.poll_event());
@@ -869,7 +870,7 @@ mod tests {
         socket_z.send(Message::with_payload(payload.clone()), &SendOptions::default()).unwrap();
 
         // A <- DATA <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
         // A /lost/ <- DATA <- Z
         expect_sent_packet!(socket_z.poll_event());
 
@@ -901,7 +902,7 @@ mod tests {
             })],
         }))
         .build();
-        socket_a.handle_input(&packet);
+        socket_a.handle_input(packet);
         let packet =
             SctpPacket::from_bytes(&expect_sent_packet!(socket_a.poll_event()), &options).unwrap();
         assert_eq!(packet.chunks.len(), 1);
@@ -935,13 +936,13 @@ mod tests {
         assert!(matches!(packet.chunks[0], Chunk::HeartbeatRequest { .. }));
 
         // Feed it to Sock-z and expect a HEARTBEAT_ACK that will be propagated back.
-        socket_z.handle_input(&request_packet);
+        socket_z.handle_input(request_packet);
         let ack_packet = expect_sent_packet!(socket_z.poll_event());
         let packet = SctpPacket::from_bytes(&ack_packet, &options).unwrap();
         assert_eq!(packet.chunks.len(), 1);
         assert!(matches!(packet.chunks[0], Chunk::HeartbeatAck { .. }));
 
-        socket_a.handle_input(&ack_packet);
+        socket_a.handle_input(ack_packet);
     }
 
     #[test]
@@ -965,10 +966,10 @@ mod tests {
         socket_a.send(Message::with_size(2), &SendOptions::default()).unwrap();
 
         // A -> DATA -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         assert!(socket_z.get_next_message().is_some());
         // A <- SACK <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
 
         // Verify that the heartbeat timer was restarted by the sent DATA.
         socket_a.advance_time(original_heartbeat_timeout);
@@ -1149,7 +1150,7 @@ mod tests {
         )
         .add(&Chunk::HeartbeatAck(HeartbeatAckChunk { parameters: req.parameters }))
         .build();
-        socket_a.handle_input(&ack_packet);
+        socket_a.handle_input(ack_packet);
 
         // Should suffice as exceeding RTO - which will not fire.
         now = now + Duration::from_secs(1);
@@ -1198,7 +1199,7 @@ mod tests {
             panic!();
         };
         socket_a.handle_input(
-            &SctpPacketBuilder::new(
+            SctpPacketBuilder::new(
                 socket_a.verification_tag(),
                 options.local_port,
                 options.remote_port,
@@ -1236,10 +1237,10 @@ mod tests {
         socket_a.send(Message::with_size(2), &SendOptions::default()).unwrap();
 
         // A -> DATA -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         assert!(socket_z.get_next_message().is_some());
         // A <- SACK <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
 
         // Reset the outgoing stream. This will directly send a RE-CONFIG.
         socket_a.reset_streams(&[StreamId(1)]).unwrap();
@@ -1248,14 +1249,14 @@ mod tests {
         // will also send a RE-CONFIG with a response.
         expect_no_event!(socket_z.poll_event());
         // A -> RECONFIG -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         let streams = expect_on_incoming_stream_reset!(socket_z.poll_event());
         assert_eq!(streams, &[StreamId(1)]);
 
         // Receiving a response will trigger a callback. Streams are now reset.
         expect_no_event!(socket_a.poll_event());
         // A <- RECONFIG <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
         let streams = expect_on_streams_reset_performed!(socket_a.poll_event());
         assert_eq!(streams, &[StreamId(1)]);
         expect_no_event!(socket_z.poll_event());
@@ -1296,12 +1297,12 @@ mod tests {
         socket_a.send(Message::with_payload(payload.clone()), &SendOptions::default()).unwrap();
         socket_a.send(Message::with_payload(payload.clone()), &SendOptions::default()).unwrap();
         // A -> DATA -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         // A -> DATA -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         // A <- SACK <- Z
         assert!(socket_z.get_next_message().is_some());
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
 
         assert!(socket_z.get_next_message().is_some());
 
@@ -1311,23 +1312,23 @@ mod tests {
         // TODO: Verify SSNs. Right now verified in Wireshark.
         // A -> RECONFIG -> Z
         let packet = expect_sent_packet!(socket_a.poll_event());
-        socket_z.handle_input(&packet);
+        socket_z.handle_input(packet);
         expect_on_incoming_stream_reset!(socket_z.poll_event());
         // A <- RECONFIG + SACK (Bundled) <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
         expect_on_streams_reset_performed!(socket_a.poll_event());
 
         socket_a.send(Message::with_payload(payload.clone()), &SendOptions::default()).unwrap();
         socket_a.send(Message::with_payload(payload.clone()), &SendOptions::default()).unwrap();
 
         // A -> DATA -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         // A -> DATA -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         assert_eq!(socket_z.messages_ready_count(), 2);
 
         // A <- SACK <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
 
         expect_no_event!(socket_a.poll_event());
         expect_no_event!(socket_z.poll_event());
@@ -1409,7 +1410,7 @@ mod tests {
         // receiving side should get it in full.
         socket_a.send(Message::with_size(options.mtu * 10), &SendOptions::default()).unwrap();
 
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
 
         // Create a new association, z2 - and don't use z anymore.
         let mut socket_z2 = Socket::new("Z2", &options);
@@ -1439,19 +1440,19 @@ mod tests {
         socket_a.send(Message::new(StreamId(1), PpId(53), data.clone()), &s).unwrap();
 
         // A -> DATA -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         assert_eq!(socket_z.get_next_message().unwrap().ppid, PpId(51));
 
         // A <- SACK <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
 
         // A -> DATA -> /lost/ Z
         expect_sent_packet!(socket_a.poll_event());
         // A -> DATA -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
 
         // A <- SACK <- Z (packet loss detected).
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
 
         expect_no_event!(socket_a.poll_event());
         expect_no_event!(socket_z.poll_event());
@@ -1467,7 +1468,7 @@ mod tests {
         // FORWARD-TSN to be sent.
 
         // A -> FORWARD-TSN -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         assert_eq!(socket_z.get_next_message().unwrap().ppid, PpId(53));
 
         // Delayed SACK
@@ -1475,7 +1476,7 @@ mod tests {
         socket_z.advance_time(now);
 
         // A <- SACK <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
 
         expect_no_event!(socket_a.poll_event());
         expect_no_event!(socket_z.poll_event());
@@ -1567,7 +1568,7 @@ mod tests {
             SctpPacket::from_bytes(&packet, &options).unwrap().chunks[0],
             Chunk::Data(_)
         ));
-        socket_z.handle_input(&packet);
+        socket_z.handle_input(packet);
         assert!(socket_z.get_next_message().is_some());
 
         let packet = expect_sent_packet!(socket_z.poll_event());
@@ -1575,7 +1576,7 @@ mod tests {
             SctpPacket::from_bytes(&packet, &options).unwrap().chunks[0],
             Chunk::Sack(_)
         ));
-        socket_a.handle_input(&packet);
+        socket_a.handle_input(packet);
 
         // Send another message
         socket_a.send(Message::with_size(2), &SendOptions::default()).unwrap();
@@ -1622,8 +1623,8 @@ mod tests {
             Chunk::HeartbeatRequest(_)
         ));
 
-        socket_z.handle_input(&packet);
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_z.handle_input(packet);
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
 
         now = now + options_z.heartbeat_interval - options_a.heartbeat_interval;
         socket_a.advance_time(now);
@@ -1727,21 +1728,21 @@ mod tests {
         socket_a.send(Message::new(StreamId(1), PpId(54), p.clone()), &s).unwrap();
 
         // A -> DATA (msg 1, fragment 1) -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         // A -> DATA (msg 1, fragment 2) /lost/ -> Z
         expect_sent_packet!(socket_a.poll_event());
         // A -> DATA (msg 2, fragment 1) -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         // A -> DATA (msg 2, fragment 2) /lost/ -> Z
         expect_sent_packet!(socket_a.poll_event());
         // A -> DATA (msg 3, fragment 1) -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         // A -> DATA (msg 3, fragment 2) /lost/ -> Z
         expect_sent_packet!(socket_a.poll_event());
         // A -> DATA (msg 4, fragment 1) -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         // A -> DATA (msg 4, fragment 2) -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
 
         exchange_packets(&mut socket_a, &mut socket_z);
 
@@ -1764,7 +1765,7 @@ mod tests {
         )
         .add(&Chunk::Unknown(UnknownChunk { typ: 0x49, flags: 0, value: vec![] }))
         .build();
-        socket_a.handle_input(&packet);
+        socket_a.handle_input(packet);
 
         assert_eq!(expect_on_error!(socket_a.poll_event()), ErrorKind::ParseFailed);
     }
@@ -1788,7 +1789,7 @@ mod tests {
             })],
         }))
         .build();
-        socket_a.handle_input(&packet);
+        socket_a.handle_input(packet);
 
         assert_eq!(expect_on_error!(socket_a.poll_event()), ErrorKind::PeerReported);
     }
@@ -1844,13 +1845,13 @@ mod tests {
             let mut again = false;
             if let Some(e) = socket_a.poll_event() {
                 if let SocketEvent::SendPacket(send) = e {
-                    socket_z.handle_input(&send);
+                    socket_z.handle_input(send);
                 }
                 again = true;
             }
             if let Some(e) = socket_z.poll_event() {
                 if let SocketEvent::SendPacket(send) = e {
-                    socket_a.handle_input(&send);
+                    socket_a.handle_input(send);
                 }
                 again = true;
             }
@@ -1892,13 +1893,13 @@ mod tests {
             let mut again = false;
             if let Some(e) = socket_a.poll_event() {
                 if let SocketEvent::SendPacket(send) = e {
-                    socket_z.handle_input(&send);
+                    socket_z.handle_input(send);
                 }
                 again = true;
             }
             if let Some(e) = socket_z.poll_event() {
                 if let SocketEvent::SendPacket(send) = e {
-                    socket_a.handle_input(&send);
+                    socket_a.handle_input(send);
                 }
                 again = true;
             }
@@ -2198,11 +2199,11 @@ mod tests {
         assert_eq!(metrics.unack_data_count, 1);
 
         // A -> DATA -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         assert_eq!(socket_z.messages_ready_count(), 1);
 
         // A <- SACK <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
 
         let metrics = socket_a.get_metrics().unwrap();
         // The reassembled message is still in the socket, and not consumed, so the receiver window
@@ -2223,19 +2224,19 @@ mod tests {
         assert_eq!(metrics.unack_data_count, 3);
 
         // A -> DATA -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         expect_no_event!(socket_z.poll_event());
         // A -> DATA -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         // A <- SACK <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
 
         let metrics = socket_a.get_metrics().unwrap();
         assert_eq!(metrics.unack_data_count, 1);
         assert!(metrics.peer_rwnd_bytes > 0 && metrics.peer_rwnd_bytes < initial_a_rwnd);
 
         // A -> DATA -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         assert_eq!(socket_z.messages_ready_count(), 2);
         socket_z.get_next_message().unwrap();
         socket_z.get_next_message().unwrap();
@@ -2246,7 +2247,7 @@ mod tests {
         socket_z.advance_time(now);
 
         // A <- SACK <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
 
         let metrics = socket_a.get_metrics().unwrap();
         assert_eq!(metrics.unack_data_count, 0);
@@ -2267,7 +2268,7 @@ mod tests {
 
         // Receive first packet, drop second, receive and retransmit the remaining.
         // A -> DATA -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         expect_sent_packet!(socket_a.poll_event());
         exchange_packets(&mut socket_a, &mut socket_z);
 
@@ -2581,7 +2582,7 @@ mod tests {
         connect_sockets(&mut socket_a, &mut socket_z);
 
         socket_a.set_stream_priority(StreamId(1), 0);
-        let payload = vec![1, 2, 3];
+        let payload = Bytes::from_static(&[1, 2, 3]);
         socket_a.send(Message::with_payload(payload.clone()), &SendOptions::default()).unwrap();
 
         exchange_packets(&mut socket_a, &mut socket_z);
@@ -2815,7 +2816,7 @@ mod tests {
 
         // A -> DATA -> Z
         expect_on_lifecycle_message_fully_sent!(socket_a.poll_event());
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         // A -> DATA -> /lost/ Z
         expect_on_lifecycle_message_fully_sent!(socket_a.poll_event());
         expect_sent_packet!(socket_a.poll_event());
@@ -2849,7 +2850,7 @@ mod tests {
             .unwrap();
 
         // A -> DATA -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         // A -> DATA -> /lost/ Z
         expect_sent_packet!(socket_a.poll_event());
 
@@ -2953,18 +2954,18 @@ mod tests {
         ));
 
         // Receive them slightly out of order to make stream resetting deferred.
-        socket_z.handle_input(&reconfig);
+        socket_z.handle_input(reconfig);
         // A <- RECONFIG RESPONSE(in progress) <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
-        socket_z.handle_input(&data1);
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
+        socket_z.handle_input(data1);
         // A <- SACK <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
-        socket_z.handle_input(&data2);
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
+        socket_z.handle_input(data2);
         assert_eq!(socket_z.get_next_message().unwrap().ppid, PpId(53));
-        socket_z.handle_input(&data3);
+        socket_z.handle_input(data3);
         assert_eq!(socket_z.get_next_message().unwrap().ppid, PpId(54));
         // A <- SACK <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
 
         // Z sent "in progress", which will make A buffer packets until it's sure that the
         // reconfiguration has been applied. A will retry - wait for that.
@@ -2975,7 +2976,7 @@ mod tests {
             SctpPacket::from_bytes(&packet, &options).unwrap().chunks[0],
             Chunk::ReConfig(_)
         ));
-        socket_z.handle_input(&packet);
+        socket_z.handle_input(packet);
 
         expect_on_incoming_stream_reset!(socket_z.poll_event());
 
@@ -2984,7 +2985,7 @@ mod tests {
             SctpPacket::from_bytes(&packet, &options).unwrap().chunks[0],
             Chunk::ReConfig(_)
         ));
-        socket_a.handle_input(&packet);
+        socket_a.handle_input(packet);
 
         expect_on_streams_reset_performed!(socket_a.poll_event());
 
@@ -3083,7 +3084,7 @@ mod tests {
         let mut socket_z = Socket::new("Z", &options);
         socket_a.connect();
         // A -> INIT -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
 
         // A <- INIT_ACK <- Z
         let packet = expect_sent_packet!(socket_z.poll_event());
@@ -3102,9 +3103,9 @@ mod tests {
         let mut socket_z = Socket::new("Z", &options);
         socket_a.connect();
         // A -> INIT -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         // A <- INIT_ACK <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
 
         // A -> COOKIE_ECHO -> Z
         let packet = expect_sent_packet!(socket_a.poll_event());
@@ -3123,11 +3124,11 @@ mod tests {
         let mut socket_z = Socket::new("Z", &options);
         socket_a.connect();
         // A -> INIT -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         // A <- INIT_ACK <- Z
-        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a.handle_input(expect_sent_packet!(socket_z.poll_event()));
         // A -> COOKIE_ECHO -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a.poll_event()));
         expect_on_connected!(socket_z.poll_event());
 
         // A <- COOOKIE_ACK <- Z
@@ -3174,7 +3175,7 @@ mod tests {
                 if let SocketEvent::SendPacket(send) = e {
                     let packet = SctpPacket::from_bytes(&send, &options).unwrap();
                     assert_eq!(packet.common_header.checksum, 0);
-                    socket_z.handle_input(&send);
+                    socket_z.handle_input(send);
                 }
                 continue;
             }
@@ -3182,7 +3183,7 @@ mod tests {
                 if let SocketEvent::SendPacket(send) = e {
                     let packet = SctpPacket::from_bytes(&send, &options).unwrap();
                     assert_eq!(packet.common_header.checksum, 0);
-                    socket_a.handle_input(&send);
+                    socket_a.handle_input(send);
                 }
                 continue;
             }
@@ -3227,8 +3228,8 @@ mod tests {
         ));
 
         // These two packets are received in the wrong order.
-        socket_z.handle_input(&reconfig_packet);
-        socket_z.handle_input(&fwd_tsn_packet);
+        socket_z.handle_input(reconfig_packet);
+        socket_z.handle_input(fwd_tsn_packet);
         exchange_packets(&mut socket_a, &mut socket_z);
 
         // Send two more messages.
@@ -3240,7 +3241,7 @@ mod tests {
             .unwrap();
 
         let data_packet = expect_sent_packet!(socket_a.poll_event());
-        socket_z.handle_input(&data_packet.clone());
+        socket_z.handle_input(data_packet.clone());
         let data_packet = SctpPacket::from_bytes(&data_packet, &options).unwrap();
         let Chunk::Data(c) = &data_packet.chunks[0] else {
             panic!();
@@ -3249,7 +3250,7 @@ mod tests {
         assert_eq!(c.data.ppid, PpId(52));
 
         let data_packet = expect_sent_packet!(socket_a.poll_event());
-        socket_z.handle_input(&data_packet.clone());
+        socket_z.handle_input(data_packet.clone());
         let data_packet = SctpPacket::from_bytes(&data_packet, &options).unwrap();
         let Chunk::Data(c) = &data_packet.chunks[0] else {
             panic!();
@@ -3299,13 +3300,13 @@ mod tests {
         socket_a.connect();
         // A -> INIT -> Z
         let first_packet = expect_sent_packet!(socket_a.poll_event());
-        socket_z.handle_input(&first_packet.clone());
+        socket_z.handle_input(first_packet.clone());
         // A <- INIT_ACK <- Z
         let init_ack_packet1 = expect_sent_packet!(socket_z.poll_event());
         expect_no_event!(socket_z.poll_event());
 
         // Get another INIT_ACK;
-        socket_z.handle_input(&first_packet);
+        socket_z.handle_input(first_packet);
         let init_ack_packet2 = expect_sent_packet!(socket_z.poll_event());
         expect_no_event!(socket_z.poll_event());
 
@@ -3332,14 +3333,14 @@ mod tests {
         // A -> INIT -> Z
         let init_packet = expect_sent_packet!(socket_a.poll_event());
         // Extract two INIT-ACKs.
-        socket_z.handle_input(&init_packet.clone());
+        socket_z.handle_input(init_packet.clone());
         let init_ack_packet1 = expect_sent_packet!(socket_z.poll_event());
-        socket_z.handle_input(&init_packet);
+        socket_z.handle_input(init_packet);
         let init_ack_packet2 = expect_sent_packet!(socket_z.poll_event());
         assert_ne!(init_ack_packet1, init_ack_packet2);
 
         // A <- INIT_ACK <- Z
-        socket_a.handle_input(&init_ack_packet1);
+        socket_a.handle_input(init_ack_packet1);
 
         let (events_a, events_z) = exchange_packets(&mut socket_a, &mut socket_z);
         assert!(events_a.iter().any(|e| matches!(e, SocketEvent::OnConnected(..))));
@@ -3364,14 +3365,14 @@ mod tests {
         // A -> INIT -> Z
         let init_packet = expect_sent_packet!(socket_a.poll_event());
         // Extract two INIT-ACKs.
-        socket_z.handle_input(&init_packet.clone());
+        socket_z.handle_input(init_packet.clone());
         let init_ack_packet1 = expect_sent_packet!(socket_z.poll_event());
-        socket_z.handle_input(&init_packet);
+        socket_z.handle_input(init_packet);
         let init_ack_packet2 = expect_sent_packet!(socket_z.poll_event());
         assert_ne!(init_ack_packet1, init_ack_packet2);
 
         // A <- INIT_ACK <- Z
-        socket_a.handle_input(&init_ack_packet2);
+        socket_a.handle_input(init_ack_packet2);
 
         let (events_a, events_z) = exchange_packets(&mut socket_a, &mut socket_z);
         assert!(events_a.iter().any(|e| matches!(e, SocketEvent::OnConnected(..))));
@@ -3393,22 +3394,22 @@ mod tests {
         // 1. Z resets stream 1. A1 processes it.
         socket_z.reset_streams(&[StreamId(1)]).unwrap();
         // Z -> RECONFIG -> A1
-        socket_a1.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a1.handle_input(expect_sent_packet!(socket_z.poll_event()));
         let streams = expect_on_incoming_stream_reset!(socket_a1.poll_event());
         assert_eq!(streams, &[StreamId(1)]);
         // Z <- RECONFIG (Response) <- A1
-        socket_z.handle_input(&expect_sent_packet!(socket_a1.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a1.poll_event()));
         let streams = expect_on_streams_reset_performed!(socket_z.poll_event());
         assert_eq!(streams, &[StreamId(1)]);
 
         // 2. A1 resets stream 1. Z processes it.
         socket_a1.reset_streams(&[StreamId(1)]).unwrap();
         // A1 -> RECONFIG -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a1.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a1.poll_event()));
         let streams = expect_on_incoming_stream_reset!(socket_z.poll_event());
         assert_eq!(streams, &[StreamId(1)]);
         // A1 <- RECONFIG (Response) <- Z
-        socket_a1.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a1.handle_input(expect_sent_packet!(socket_z.poll_event()));
         let streams = expect_on_streams_reset_performed!(socket_a1.poll_event());
         assert_eq!(streams, &[StreamId(1)]);
 
@@ -3422,11 +3423,11 @@ mod tests {
         // retransmission (and thus NOT trigger on_incoming_stream_reset).
         socket_a2.reset_streams(&[StreamId(2)]).unwrap();
         // A2 -> RECONFIG -> Z
-        socket_z.handle_input(&expect_sent_packet!(socket_a2.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a2.poll_event()));
         let streams = expect_on_incoming_stream_reset!(socket_z.poll_event());
         assert_eq!(streams, &[StreamId(2)]);
         // A2 <- RECONFIG (Response) <- Z
-        socket_a2.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a2.handle_input(expect_sent_packet!(socket_z.poll_event()));
         let streams = expect_on_streams_reset_performed!(socket_a2.poll_event());
         assert_eq!(streams, &[StreamId(2)]);
 
@@ -3436,11 +3437,11 @@ mod tests {
         // initial+1), and would return an error.
         socket_z.reset_streams(&[StreamId(2)]).unwrap();
         // Z -> RECONFIG -> A2
-        socket_a2.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+        socket_a2.handle_input(expect_sent_packet!(socket_z.poll_event()));
         let streams = expect_on_incoming_stream_reset!(socket_a2.poll_event());
         assert_eq!(streams, &[StreamId(2)]);
         // Z <- RECONFIG (Response) <- A2
-        socket_z.handle_input(&expect_sent_packet!(socket_a2.poll_event()));
+        socket_z.handle_input(expect_sent_packet!(socket_a2.poll_event()));
         let streams = expect_on_streams_reset_performed!(socket_z.poll_event());
         assert_eq!(streams, &[StreamId(2)]);
     }
@@ -3453,7 +3454,10 @@ mod tests {
 
         // Queue data on A
         socket_a
-            .send(Message::new(StreamId(1), PpId(1), b"hello".to_vec()), &SendOptions::default())
+            .send(
+                Message::new(StreamId(1), PpId(1), Bytes::from_static(b"hello")),
+                &SendOptions::default(),
+            )
             .unwrap();
 
         socket_a.connect();
@@ -3465,17 +3469,17 @@ mod tests {
         let packet_z_init = expect_sent_packet!(socket_z.poll_event());
 
         // A <- INIT
-        socket_a.handle_input(&packet_z_init);
+        socket_a.handle_input(packet_z_init);
         // A -> INIT_ACK
         let packet_a_init_ack = expect_sent_packet!(socket_a.poll_event());
 
         // Z <- INIT
-        socket_z.handle_input(&packet_a_init);
+        socket_z.handle_input(packet_a_init);
         // Z -> INIT_ACK
         let packet_z_init_ack = expect_sent_packet!(socket_z.poll_event());
 
         // A <- INIT_ACK
-        socket_a.handle_input(&packet_z_init_ack);
+        socket_a.handle_input(packet_z_init_ack);
         // A -> COOKIE_ECHO + DATA.
         let packet_a_cookie_echo = expect_sent_packet!(socket_a.poll_event());
         // Verify it contains DATA
@@ -3485,18 +3489,18 @@ mod tests {
         // DROP packet_a_cookie_echo. Z does not receive it.
 
         // Z <- INIT_ACK
-        socket_z.handle_input(&packet_a_init_ack);
+        socket_z.handle_input(packet_a_init_ack);
         // Z -> COOKIE_ECHO
         let packet_z_cookie_echo = expect_sent_packet!(socket_z.poll_event());
 
         // A <- COOKIE_ECHO. A should enter Established.
-        socket_a.handle_input(&packet_z_cookie_echo);
+        socket_a.handle_input(packet_z_cookie_echo);
         expect_on_connected!(socket_a.poll_event());
         // A -> COOKIE_ACK
         let packet_a_cookie_ack = expect_sent_packet!(socket_a.poll_event());
 
         // Z <- COOKIE_ACK. Z should enter Established.
-        socket_z.handle_input(&packet_a_cookie_ack);
+        socket_z.handle_input(packet_a_cookie_ack);
         expect_on_connected!(socket_z.poll_event());
 
         // Now A should retransmit the lost DATA after RTO.
@@ -3510,7 +3514,7 @@ mod tests {
         assert!(packet.chunks.iter().any(|c| matches!(c, Chunk::Data(_))));
 
         // Z <- DATA
-        socket_z.handle_input(&packet_retransmit);
+        socket_z.handle_input(packet_retransmit);
 
         // Z should have received the message
         let msg = socket_z.get_next_message().unwrap();
@@ -3530,7 +3534,7 @@ mod tests {
         socket_a.send(Message::with_size(5), &SendOptions::default()).unwrap();
 
         let packet = expect_sent_packet!(socket_a.poll_event());
-        socket_z.handle_input(&packet);
+        socket_z.handle_input(packet);
 
         let packet = expect_sent_packet!(socket_z.poll_event());
         let packet = SctpPacket::from_bytes(&packet, &options).unwrap();
@@ -3541,7 +3545,7 @@ mod tests {
         socket_a.send(Message::with_size(5), &SendOptions::default()).unwrap();
         let packet = expect_sent_packet!(socket_a.poll_event());
 
-        socket_z.handle_input(&packet);
+        socket_z.handle_input(packet);
         expect_no_event!(socket_z.poll_event());
 
         let next_timeout = socket_z.poll_timeout();

--- a/src/socket/socket_tests.rs
+++ b/src/socket/socket_tests.rs
@@ -94,6 +94,25 @@ mod tests {
         }
     }
 
+    fn zeroed_bytes(size: usize) -> Vec<u8> {
+        vec![0; size]
+    }
+
+    trait MessageTestExt {
+        fn with_size(size: usize) -> Self;
+        fn with_payload(payload: Vec<u8>) -> Self;
+    }
+
+    impl MessageTestExt for Message {
+        fn with_size(size: usize) -> Self {
+            Message::new(StreamId(1), PpId(53), zeroed_bytes(size))
+        }
+
+        fn with_payload(payload: Vec<u8>) -> Self {
+            Message::new(StreamId(1), PpId(53), payload)
+        }
+    }
+
     fn exchange_packets(
         socket_a: &mut Socket,
         socket_z: &mut Socket,
@@ -103,16 +122,16 @@ mod tests {
         loop {
             let mut again = false;
             if let Some(e) = socket_a.poll_event() {
-                if let SocketEvent::SendPacket(ref send) = e {
-                    socket_z.handle_input(send);
+                if let SocketEvent::SendPacket(send) = e {
+                    socket_z.handle_input(&send);
                 } else {
                     events_a.push_back(e);
                 }
                 again = true;
             }
             if let Some(e) = socket_z.poll_event() {
-                if let SocketEvent::SendPacket(ref send) = e {
-                    socket_a.handle_input(send);
+                if let SocketEvent::SendPacket(send) = e {
+                    socket_a.handle_input(&send);
                 } else {
                     events_z.push_back(e);
                 }
@@ -213,11 +232,11 @@ mod tests {
         exchange_packets(&mut socket_a, &mut socket_z);
 
         let msg1 = socket_z.get_next_message().unwrap();
-        assert_eq!(msg1.payload, b"hello");
+        assert_eq!(&msg1.payload[..], b"hello");
         assert_eq!(msg1.stream_id, StreamId(1));
 
         let msg2 = socket_z.get_next_message().unwrap();
-        assert_eq!(msg2.payload, b"world");
+        assert_eq!(&msg2.payload[..], b"world");
         assert_eq!(msg2.stream_id, StreamId(2));
     }
 
@@ -521,12 +540,7 @@ mod tests {
         let mut socket_z = Socket::new("Z", &options);
 
         let payload_size = options.mtu + 100;
-        socket_a
-            .send(
-                Message::new(StreamId(1), PpId(53), vec![0; payload_size]),
-                &SendOptions::default(),
-            )
-            .unwrap();
+        socket_a.send(Message::with_size(payload_size), &SendOptions::default()).unwrap();
         socket_a.connect();
         // A -> INIT -> Z
         socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
@@ -743,9 +757,7 @@ mod tests {
 
         // Send a message that will remain outstanding (unacknowledged) which
         // transitions the socket to SHUTDOWN-PENDING instead of SHUTDOWN-SENT.
-        socket_a
-            .send(Message::new(StreamId(1), PpId(53), vec![1, 2]), &SendOptions::default())
-            .unwrap();
+        socket_a.send(Message::with_size(2), &SendOptions::default()).unwrap();
         socket_a.shutdown();
 
         let packet = expect_sent_packet!(socket_a.poll_event());
@@ -852,11 +864,9 @@ mod tests {
         let mut socket_z = Socket::new("Z", &options);
         connect_sockets(&mut socket_a, &mut socket_z);
 
-        let payload: Vec<u8> = vec![0; 20 * options.mtu];
+        let payload = zeroed_bytes(20 * options.mtu);
 
-        socket_z
-            .send(Message::new(StreamId(1), PpId(53), payload.clone()), &SendOptions::default())
-            .unwrap();
+        socket_z.send(Message::with_payload(payload.clone()), &SendOptions::default()).unwrap();
 
         // A <- DATA <- Z
         socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
@@ -952,9 +962,7 @@ mod tests {
         socket_a.advance_time(now);
         socket_z.advance_time(now);
 
-        socket_a
-            .send(Message::new(StreamId(1), PpId(53), vec![1, 2]), &SendOptions::default())
-            .unwrap();
+        socket_a.send(Message::with_size(2), &SendOptions::default()).unwrap();
 
         // A -> DATA -> Z
         socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
@@ -1225,9 +1233,7 @@ mod tests {
         let mut socket_z = Socket::new("Z", &options);
         connect_sockets(&mut socket_a, &mut socket_z);
 
-        socket_a
-            .send(Message::new(StreamId(1), PpId(53), vec![1, 2]), &SendOptions::default())
-            .unwrap();
+        socket_a.send(Message::with_size(2), &SendOptions::default()).unwrap();
 
         // A -> DATA -> Z
         socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
@@ -1265,11 +1271,11 @@ mod tests {
 
         let ordered = SendOptions { unordered: false, ..Default::default() };
 
-        socket_a.send(Message::new(StreamId(1), PpId(51), vec![0; 3000]), &ordered).unwrap();
+        socket_a.send(Message::new(StreamId(1), PpId(51), zeroed_bytes(3000)), &ordered).unwrap();
 
         socket_a.reset_streams(&[StreamId(1)]).unwrap();
 
-        socket_a.send(Message::new(StreamId(1), PpId(53), vec![0; 100]), &ordered).unwrap();
+        socket_a.send(Message::new(StreamId(1), PpId(53), zeroed_bytes(100)), &ordered).unwrap();
 
         exchange_packets(&mut socket_a, &mut socket_z);
 
@@ -1286,18 +1292,9 @@ mod tests {
         let mut socket_z = Socket::new("Z", &options);
         connect_sockets(&mut socket_a, &mut socket_z);
 
-        socket_a
-            .send(
-                Message::new(StreamId(1), PpId(53), vec![0; options.mtu - 100]),
-                &SendOptions::default(),
-            )
-            .unwrap();
-        socket_a
-            .send(
-                Message::new(StreamId(1), PpId(53), vec![0; options.mtu - 100]),
-                &SendOptions::default(),
-            )
-            .unwrap();
+        let payload = zeroed_bytes(options.mtu - 100);
+        socket_a.send(Message::with_payload(payload.clone()), &SendOptions::default()).unwrap();
+        socket_a.send(Message::with_payload(payload.clone()), &SendOptions::default()).unwrap();
         // A -> DATA -> Z
         socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
         // A -> DATA -> Z
@@ -1320,18 +1317,8 @@ mod tests {
         socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
         expect_on_streams_reset_performed!(socket_a.poll_event());
 
-        socket_a
-            .send(
-                Message::new(StreamId(1), PpId(53), vec![0; options.mtu - 100]),
-                &SendOptions::default(),
-            )
-            .unwrap();
-        socket_a
-            .send(
-                Message::new(StreamId(1), PpId(53), vec![0; options.mtu - 100]),
-                &SendOptions::default(),
-            )
-            .unwrap();
+        socket_a.send(Message::with_payload(payload.clone()), &SendOptions::default()).unwrap();
+        socket_a.send(Message::with_payload(payload.clone()), &SendOptions::default()).unwrap();
 
         // A -> DATA -> Z
         socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
@@ -1355,7 +1342,7 @@ mod tests {
 
         // Send two ordered messages on SID 1
         let s = SendOptions::default();
-        let payload = vec![0; options.mtu - 100];
+        let payload = zeroed_bytes(options.mtu - 100);
         socket_a.send(Message::new(StreamId(1), PpId(53), payload.clone()), &s).unwrap();
         socket_a.send(Message::new(StreamId(1), PpId(53), payload.clone()), &s).unwrap();
 
@@ -1420,12 +1407,7 @@ mod tests {
 
         // Let's be evil here - reconnect while a fragmented packet was about to be sent. The
         // receiving side should get it in full.
-        socket_a
-            .send(
-                Message::new(StreamId(1), PpId(51), vec![0; options.mtu * 10]),
-                &SendOptions::default(),
-            )
-            .unwrap();
+        socket_a.send(Message::with_size(options.mtu * 10), &SendOptions::default()).unwrap();
 
         socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
 
@@ -1439,7 +1421,7 @@ mod tests {
         exchange_packets(&mut socket_a, &mut socket_z2);
 
         let message = socket_z2.get_next_message().unwrap();
-        assert_eq!(message.ppid, PpId(51));
+        assert_eq!(message.ppid, PpId(53));
         assert!(socket_z2.get_next_message().is_none());
     }
 
@@ -1451,7 +1433,7 @@ mod tests {
         let mut socket_z = Socket::new("Z", &options);
         connect_sockets(&mut socket_a, &mut socket_z);
         let s = SendOptions { max_retransmissions: Some(0), ..Default::default() };
-        let data = vec![0; options.mtu - 100];
+        let data = zeroed_bytes(options.mtu - 100);
         socket_a.send(Message::new(StreamId(1), PpId(51), data.clone()), &s).unwrap();
         socket_a.send(Message::new(StreamId(1), PpId(52), data.clone()), &s).unwrap();
         socket_a.send(Message::new(StreamId(1), PpId(53), data.clone()), &s).unwrap();
@@ -1508,9 +1490,7 @@ mod tests {
         let mut socket_z = Socket::new("Z", &options);
         connect_sockets(&mut socket_a, &mut socket_z);
 
-        socket_a
-            .send(Message::new(StreamId(1), PpId(51), vec![0; 2]), &SendOptions::default())
-            .unwrap();
+        socket_a.send(Message::with_size(2), &SendOptions::default()).unwrap();
 
         // Dropping first transmission.
         let packet = expect_sent_packet!(socket_a.poll_event());
@@ -1538,9 +1518,7 @@ mod tests {
         let mut socket_z = Socket::new("Z", &options);
         connect_sockets(&mut socket_a, &mut socket_z);
 
-        socket_a
-            .send(Message::new(StreamId(1), PpId(51), vec![0; 2]), &SendOptions::default())
-            .unwrap();
+        socket_a.send(Message::with_size(2), &SendOptions::default()).unwrap();
         // Dropping first transmission.
         let packet = expect_sent_packet!(socket_a.poll_event());
         let packet = SctpPacket::from_bytes(&packet, &options).unwrap();
@@ -1574,9 +1552,7 @@ mod tests {
         let mut socket_z = Socket::new("Z", &options);
         connect_sockets(&mut socket_a, &mut socket_z);
 
-        socket_a
-            .send(Message::new(StreamId(1), PpId(51), vec![0; 2]), &SendOptions::default())
-            .unwrap();
+        socket_a.send(Message::with_size(2), &SendOptions::default()).unwrap();
         // Dropping first transmission.
         let packet = expect_sent_packet!(socket_a.poll_event());
         let packet = SctpPacket::from_bytes(&packet, &options).unwrap();
@@ -1602,9 +1578,7 @@ mod tests {
         socket_a.handle_input(&packet);
 
         // Send another message
-        socket_a
-            .send(Message::new(StreamId(1), PpId(51), vec![0; 2]), &SendOptions::default())
-            .unwrap();
+        socket_a.send(Message::with_size(2), &SendOptions::default()).unwrap();
 
         // Dropping first transmission of second message. The TX error counter recovered before.
         let packet = expect_sent_packet!(socket_a.poll_event());
@@ -1672,9 +1646,7 @@ mod tests {
         let mut socket_z = Socket::new("Z", &options);
         connect_sockets(&mut socket_a, &mut socket_z);
 
-        socket_a
-            .send(Message::new(StreamId(1), PpId(51), vec![0; 2]), &SendOptions::default())
-            .unwrap();
+        socket_a.send(Message::with_size(2), &SendOptions::default()).unwrap();
         // Dropping first transmission.
         let packet = expect_sent_packet!(socket_a.poll_event());
         let packet = SctpPacket::from_bytes(&packet, &options).unwrap();
@@ -1713,9 +1685,7 @@ mod tests {
         let mut socket_z = Socket::new("Z", &options);
         connect_sockets(&mut socket_a, &mut socket_z);
 
-        socket_a
-            .send(Message::new(StreamId(1), PpId(51), vec![0; 2]), &SendOptions::default())
-            .unwrap();
+        socket_a.send(Message::with_size(2), &SendOptions::default()).unwrap();
         // Dropping first transmission.
         let packet = expect_sent_packet!(socket_a.poll_event());
         let packet = SctpPacket::from_bytes(&packet, &options).unwrap();
@@ -1750,7 +1720,7 @@ mod tests {
 
         let s =
             SendOptions { unordered: true, max_retransmissions: Some(0), ..SendOptions::default() };
-        let p = vec![0; 2 * options.mtu - 100 /* margin */];
+        let p = zeroed_bytes(2 * options.mtu - 100 /* margin */);
         socket_a.send(Message::new(StreamId(1), PpId(51), p.clone()), &s).unwrap();
         socket_a.send(Message::new(StreamId(1), PpId(52), p.clone()), &s).unwrap();
         socket_a.send(Message::new(StreamId(1), PpId(53), p.clone()), &s).unwrap();
@@ -1838,9 +1808,7 @@ mod tests {
 
         const ITERATIONS: usize = 100;
         for _ in 0..ITERATIONS {
-            socket_a
-                .send(Message::new(StreamId(1), PpId(51), vec![0; 2]), &SendOptions::default())
-                .unwrap();
+            socket_a.send(Message::with_size(2), &SendOptions::default()).unwrap();
         }
 
         exchange_packets(&mut socket_a, &mut socket_z);
@@ -1864,7 +1832,7 @@ mod tests {
                 lifetime: Some(Duration::from_millis(i as u64 % 3)),
                 ..Default::default()
             };
-            socket_a.send(Message::new(StreamId(1), PpId(51), vec![0; 2]), &s).unwrap();
+            socket_a.send(Message::with_size(2), &s).unwrap();
         }
 
         loop {
@@ -1902,12 +1870,7 @@ mod tests {
         connect_sockets(&mut socket_a, &mut socket_z);
 
         // Fill up the send buffer with a large message.
-        socket_a
-            .send(
-                Message::new(StreamId(1), PpId(51), vec![0; 20 * options.mtu]),
-                &SendOptions::default(),
-            )
-            .unwrap();
+        socket_a.send(Message::with_size(20 * options.mtu), &SendOptions::default()).unwrap();
 
         let lifetime_0 =
             SendOptions { unordered: true, lifetime: Some(Duration::ZERO), ..Default::default() };
@@ -1916,9 +1879,9 @@ mod tests {
             lifetime: Some(Duration::from_millis(1)),
             ..Default::default()
         };
-        socket_a.send(Message::new(StreamId(1), PpId(51), vec![0; 3]), &lifetime_0).unwrap();
-        socket_a.send(Message::new(StreamId(1), PpId(51), vec![0; 3]), &lifetime_1).unwrap();
-        socket_a.send(Message::new(StreamId(1), PpId(51), vec![0; 2]), &lifetime_0).unwrap();
+        socket_a.send(Message::with_size(3), &lifetime_0).unwrap();
+        socket_a.send(Message::with_size(3), &lifetime_1).unwrap();
+        socket_a.send(Message::with_size(2), &lifetime_0).unwrap();
 
         loop {
             // Mock that the time always goes forward.
@@ -1960,20 +1923,21 @@ mod tests {
         let lifecycle_id = LifecycleId::from(123);
         let s = SendOptions { lifecycle_id: Some(lifecycle_id.clone()), ..Default::default() };
 
-        socket.send(Message::new(StreamId(1), PpId(53), vec![0; 600]), &s).unwrap();
-        socket.send(Message::new(StreamId(1), PpId(53), vec![0; 600]), &s).unwrap();
+        let payload = zeroed_bytes(600);
+        socket.send(Message::new(StreamId(1), PpId(53), payload.clone()), &s).unwrap();
+        socket.send(Message::new(StreamId(1), PpId(53), payload.clone()), &s).unwrap();
         assert_eq!(
-            socket.send(Message::new(StreamId(1), PpId(53), vec![0; 600]), &s),
+            socket.send(Message::new(StreamId(1), PpId(53), payload.clone()), &s),
             Err(SendError::ResourceExhaustion)
         );
         assert_eq!(expect_on_lifecycle_end!(socket.poll_event()), lifecycle_id.clone());
         assert_eq!(expect_on_error!(socket.poll_event()), ErrorKind::ResourceExhaustion);
 
         // The per-stream limit for SID=1 is reached, but not SID=2.
-        socket.send(Message::new(StreamId(2), PpId(53), vec![0; 600]), &s).unwrap();
-        socket.send(Message::new(StreamId(2), PpId(53), vec![0; 600]), &s).unwrap();
+        socket.send(Message::new(StreamId(2), PpId(53), payload.clone()), &s).unwrap();
+        socket.send(Message::new(StreamId(2), PpId(53), payload.clone()), &s).unwrap();
         assert_eq!(
-            socket.send(Message::new(StreamId(2), PpId(53), vec![0; 600]), &s),
+            socket.send(Message::new(StreamId(2), PpId(53), payload.clone()), &s),
             Err(SendError::ResourceExhaustion)
         );
         assert_eq!(expect_on_lifecycle_end!(socket.poll_event()), lifecycle_id.clone());
@@ -1986,10 +1950,7 @@ mod tests {
 
         let lifecycle_id = LifecycleId::from(123);
         let s = SendOptions { lifecycle_id: Some(lifecycle_id.clone()), ..Default::default() };
-        assert_eq!(
-            socket.send(Message::new(StreamId(1), PpId(53), vec![]), &s),
-            Err(SendError::EmptyPayload)
-        );
+        assert_eq!(socket.send(Message::with_size(0), &s), Err(SendError::EmptyPayload));
 
         assert_eq!(expect_on_lifecycle_end!(socket.poll_event()), lifecycle_id.clone());
         assert_eq!(expect_on_error!(socket.poll_event()), ErrorKind::ProtocolViolation);
@@ -2003,7 +1964,7 @@ mod tests {
         let lifecycle_id = LifecycleId::from(123);
         let s = SendOptions { lifecycle_id: Some(lifecycle_id.clone()), ..Default::default() };
         assert!(matches!(
-            socket.send(Message::new(StreamId(1), PpId(53), vec![0; 101]), &s),
+            socket.send(Message::with_size(101), &s),
             Err(SendError::MessageTooLarge { .. })
         ));
 
@@ -2020,20 +1981,13 @@ mod tests {
 
         assert_eq!(socket_a.buffered_amount(StreamId(1)), 0);
 
-        socket_a
-            .send(Message::new(StreamId(1), PpId(53), vec![0; 100]), &SendOptions::default())
-            .unwrap();
+        socket_a.send(Message::with_size(100), &SendOptions::default()).unwrap();
 
         // Sending a small message will directly send it as a single packet, so nothing is left in
         // the queue.
         assert_eq!(socket_a.buffered_amount(StreamId(1)), 0);
 
-        socket_a
-            .send(
-                Message::new(StreamId(1), PpId(53), vec![0; 20 * options.mtu]),
-                &SendOptions::default(),
-            )
-            .unwrap();
+        socket_a.send(Message::with_size(20 * options.mtu), &SendOptions::default()).unwrap();
 
         // Sending a message will directly start sending a few packets, so the buffered amount is
         // not the full message size.
@@ -2057,9 +2011,7 @@ mod tests {
         expect_no_event!(socket_a.poll_event());
         expect_no_event!(socket_z.poll_event());
 
-        socket_a
-            .send(Message::new(StreamId(1), PpId(53), vec![0; 100]), &SendOptions::default())
-            .unwrap();
+        socket_a.send(Message::with_size(100), &SendOptions::default()).unwrap();
         let (mut events_a, _) = exchange_packets(&mut socket_a, &mut socket_z);
 
         assert_eq!(expect_buffered_amount_low!(events_a.pop_front()), StreamId(1));
@@ -2076,9 +2028,7 @@ mod tests {
 
         socket_a.set_buffered_amount_low_threshold(StreamId(1), 1001);
 
-        socket_a
-            .send(Message::new(StreamId(1), PpId(53), vec![0; 1000]), &SendOptions::default())
-            .unwrap();
+        socket_a.send(Message::with_size(1000), &SendOptions::default()).unwrap();
         let (mut events_a, mut events_z) = exchange_packets(&mut socket_a, &mut socket_z);
 
         expect_no_event!(events_a.pop_front());
@@ -2086,9 +2036,7 @@ mod tests {
         assert!(socket_z.get_next_message().is_some());
         assert!(socket_z.get_next_message().is_none());
 
-        socket_a
-            .send(Message::new(StreamId(1), PpId(53), vec![0; 1000]), &SendOptions::default())
-            .unwrap();
+        socket_a.send(Message::with_size(1000), &SendOptions::default()).unwrap();
         let (mut events_a, mut events_z) = exchange_packets(&mut socket_a, &mut socket_z);
         expect_no_event!(events_a.pop_front());
         expect_no_event!(events_z.pop_front());
@@ -2109,25 +2057,26 @@ mod tests {
 
         let s = SendOptions::default();
 
-        socket_a.send(Message::new(StreamId(1), PpId(53), vec![0; 1000]), &s).unwrap();
+        let payload = zeroed_bytes(1000);
+        socket_a.send(Message::new(StreamId(1), PpId(53), payload.clone()), &s).unwrap();
         let (mut events_a, _) = exchange_packets(&mut socket_a, &mut socket_z);
         assert_eq!(expect_buffered_amount_low!(events_a.pop_front()), StreamId(1));
         assert!(socket_z.get_next_message().is_some());
         assert!(socket_z.get_next_message().is_none());
 
-        socket_a.send(Message::new(StreamId(2), PpId(53), vec![0; 1000]), &s).unwrap();
+        socket_a.send(Message::new(StreamId(2), PpId(53), payload.clone()), &s).unwrap();
         let (mut events_a, _) = exchange_packets(&mut socket_a, &mut socket_z);
         assert_eq!(expect_buffered_amount_low!(events_a.pop_front()), StreamId(2));
         assert!(socket_z.get_next_message().is_some());
         assert!(socket_z.get_next_message().is_none());
 
-        socket_a.send(Message::new(StreamId(1), PpId(53), vec![0; 1000]), &s).unwrap();
+        socket_a.send(Message::new(StreamId(1), PpId(53), payload.clone()), &s).unwrap();
         let (mut events_a, _) = exchange_packets(&mut socket_a, &mut socket_z);
         assert_eq!(expect_buffered_amount_low!(events_a.pop_front()), StreamId(1));
         assert!(socket_z.get_next_message().is_some());
         assert!(socket_z.get_next_message().is_none());
 
-        socket_a.send(Message::new(StreamId(2), PpId(53), vec![0; 1000]), &s).unwrap();
+        socket_a.send(Message::new(StreamId(2), PpId(53), payload.clone()), &s).unwrap();
         let (mut events_a, _) = exchange_packets(&mut socket_a, &mut socket_z);
         assert_eq!(expect_buffered_amount_low!(events_a.pop_front()), StreamId(2));
         assert!(socket_z.get_next_message().is_some());
@@ -2146,7 +2095,7 @@ mod tests {
         // start to be fully buffered.
         while socket_a.buffered_amount(StreamId(1)) <= 1500 {
             let s = SendOptions::default();
-            socket_a.send(Message::new(StreamId(1), PpId(53), vec![0; 1000]), &s).unwrap();
+            socket_a.send(Message::with_size(1000), &s).unwrap();
         }
 
         let (mut events_a, _) = exchange_packets(&mut socket_a, &mut socket_z);
@@ -2161,7 +2110,7 @@ mod tests {
         connect_sockets(&mut socket_a, &mut socket_z);
 
         let s = SendOptions::default();
-        socket_a.send(Message::new(StreamId(1), PpId(53), vec![0; 20000]), &s).unwrap();
+        socket_a.send(Message::with_size(20000), &s).unwrap();
 
         let (mut events_a, _) = exchange_packets(&mut socket_a, &mut socket_z);
         expect_no_event!(events_a.pop_front());
@@ -2181,10 +2130,9 @@ mod tests {
 
         // Fill up the send queue completely.
         loop {
-            if let Err(SendError::ResourceExhaustion) = socket_a.send(
-                Message::new(StreamId(1), PpId(53), vec![0; 20 * 1000]),
-                &SendOptions::default(),
-            ) {
+            if let Err(SendError::ResourceExhaustion) =
+                socket_a.send(Message::with_size(20 * 1000), &SendOptions::default())
+            {
                 break;
             }
         }
@@ -2244,12 +2192,7 @@ mod tests {
         assert_eq!(metrics.rx_messages_count, 0);
 
         let payload_size = 2;
-        socket_a
-            .send(
-                Message::new(StreamId(1), PpId(53), vec![0; payload_size]),
-                &SendOptions::default(),
-            )
-            .unwrap();
+        socket_a.send(Message::with_size(payload_size), &SendOptions::default()).unwrap();
 
         let metrics = socket_a.get_metrics().unwrap();
         assert_eq!(metrics.unack_data_count, 1);
@@ -2275,12 +2218,7 @@ mod tests {
         assert_eq!(metrics.rx_messages_count, 1);
 
         // Send one more (large - fragmented), and receive the delayed SACK.
-        socket_a
-            .send(
-                Message::new(StreamId(1), PpId(53), vec![0; options.mtu * 2 + 1]),
-                &SendOptions::default(),
-            )
-            .unwrap();
+        socket_a.send(Message::with_size(options.mtu * 2 + 1), &SendOptions::default()).unwrap();
         let metrics = socket_a.get_metrics().unwrap();
         assert_eq!(metrics.unack_data_count, 3);
 
@@ -2325,12 +2263,7 @@ mod tests {
         connect_sockets(&mut socket_a, &mut socket_z);
 
         // Enough to trigger fast retransmit of the missing second packet.
-        socket_a
-            .send(
-                Message::new(StreamId(1), PpId(53), vec![0; options.mtu * 5]),
-                &SendOptions::default(),
-            )
-            .unwrap();
+        socket_a.send(Message::with_size(options.mtu * 5), &SendOptions::default()).unwrap();
 
         // Receive first packet, drop second, receive and retransmit the remaining.
         // A -> DATA -> Z
@@ -2353,9 +2286,7 @@ mod tests {
         let mut socket_z = Socket::new("Z", &options);
         connect_sockets(&mut socket_a, &mut socket_z);
 
-        socket_a
-            .send(Message::new(StreamId(1), PpId(53), vec![0; 12]), &SendOptions::default())
-            .unwrap();
+        socket_a.send(Message::with_size(12), &SendOptions::default()).unwrap();
 
         expect_sent_packet!(socket_a.poll_event());
         exchange_packets(&mut socket_a, &mut socket_z);
@@ -2373,12 +2304,7 @@ mod tests {
         connect_sockets(&mut socket_a, &mut socket_z);
 
         let message_bytes = options.mtu * 10;
-        socket_a
-            .send(
-                Message::new(StreamId(1), PpId(53), vec![0; message_bytes]),
-                &SendOptions::default(),
-            )
-            .unwrap();
+        socket_a.send(Message::with_size(message_bytes), &SendOptions::default()).unwrap();
 
         let payload_bytes = options.mtu - sctp_packet::COMMON_HEADER_SIZE - data_chunk::HEADER_SIZE;
         let expected_sent_packets = options.cwnd_mtus_initial;
@@ -2399,12 +2325,7 @@ mod tests {
         let mut socket_z = Socket::new("Z", options);
         connect_sockets(&mut socket_a, &mut socket_z);
 
-        socket_a
-            .send(
-                Message::new(StreamId(1), PpId(53), vec![0; options.mtu * 10]),
-                &SendOptions::default(),
-            )
-            .unwrap();
+        socket_a.send(Message::with_size(options.mtu * 10), &SendOptions::default()).unwrap();
 
         expect_sent_packet!(socket_a.poll_event());
         expect_sent_packet!(socket_a.poll_event());
@@ -2445,7 +2366,7 @@ mod tests {
         connect_sockets(&mut socket_a, &mut socket_z);
 
         let s = SendOptions::default();
-        socket_a.send(Message::new(StreamId(1), PpId(51), vec![0; 100]), &s).unwrap();
+        socket_a.send(Message::new(StreamId(1), PpId(51), zeroed_bytes(100)), &s).unwrap();
 
         // Send message before handover to move socket to a not initial state
         exchange_packets(&mut socket_a, &mut socket_z);
@@ -2453,9 +2374,9 @@ mod tests {
         let mut new_socket_z = Socket::new("Z2", &default_options());
         handover_socket(&mut socket_z, &mut new_socket_z);
 
-        socket_a.send(Message::new(StreamId(1), PpId(53), vec![0; 2]), &s).unwrap();
-        socket_a.send(Message::new(StreamId(2), PpId(53), vec![0; 2]), &s).unwrap();
-        socket_a.send(Message::new(StreamId(1), PpId(53), vec![0; 2]), &s).unwrap();
+        socket_a.send(Message::new(StreamId(1), PpId(53), zeroed_bytes(2)), &s).unwrap();
+        socket_a.send(Message::new(StreamId(2), PpId(53), zeroed_bytes(2)), &s).unwrap();
+        socket_a.send(Message::new(StreamId(1), PpId(53), zeroed_bytes(2)), &s).unwrap();
 
         exchange_packets(&mut socket_a, &mut new_socket_z);
         let msg = new_socket_z.get_next_message().unwrap();
@@ -2521,9 +2442,10 @@ mod tests {
             ..SendOptions::default()
         };
 
+        let message_size = options.mtu - 100;
         // Send a first message (SID=1, SSN=0)
         socket_a
-            .send(Message::new(StreamId(1), PpId(51), vec![0; options.mtu - 100]), &send_options)
+            .send(Message::new(StreamId(1), PpId(51), zeroed_bytes(message_size)), &send_options)
             .unwrap();
 
         // First DATA is lost, and retransmission timer will delete it.
@@ -2533,7 +2455,7 @@ mod tests {
 
         // Send a second message (SID=0, SSN=1).
         socket_a
-            .send(Message::new(StreamId(1), PpId(52), vec![0; options.mtu - 100]), &send_options)
+            .send(Message::new(StreamId(1), PpId(52), zeroed_bytes(message_size)), &send_options)
             .unwrap();
 
         exchange_packets(&mut socket_a, &mut socket_z);
@@ -2549,8 +2471,8 @@ mod tests {
         connect_sockets(&mut socket_a, &mut socket_z);
 
         let s = SendOptions::default();
-        socket_a.send(Message::new(StreamId(1), PpId(53), vec![0; 2]), &s).unwrap();
-        socket_a.send(Message::new(StreamId(2), PpId(53), vec![0; 2]), &s).unwrap();
+        socket_a.send(Message::new(StreamId(1), PpId(53), zeroed_bytes(2)), &s).unwrap();
+        socket_a.send(Message::new(StreamId(2), PpId(53), zeroed_bytes(2)), &s).unwrap();
 
         let (mut events_a, _) = exchange_packets(&mut socket_a, &mut socket_z);
         expect_no_event!(events_a.pop_front());
@@ -2576,9 +2498,9 @@ mod tests {
         connect_sockets(&mut socket_a, &mut socket_z);
 
         let s = SendOptions::default();
-        socket_a.send(Message::new(StreamId(1), PpId(53), vec![0; 2]), &s).unwrap();
-        socket_a.send(Message::new(StreamId(2), PpId(53), vec![0; 2]), &s).unwrap();
-        socket_a.send(Message::new(StreamId(3), PpId(53), vec![0; 2]), &s).unwrap();
+        socket_a.send(Message::new(StreamId(1), PpId(53), zeroed_bytes(2)), &s).unwrap();
+        socket_a.send(Message::new(StreamId(2), PpId(53), zeroed_bytes(2)), &s).unwrap();
+        socket_a.send(Message::new(StreamId(3), PpId(53), zeroed_bytes(2)), &s).unwrap();
 
         let (mut events_a, _) = exchange_packets(&mut socket_a, &mut socket_z);
         expect_no_event!(events_a.pop_front());
@@ -2612,9 +2534,9 @@ mod tests {
         connect_sockets(&mut socket_a, &mut socket_z);
 
         let s = SendOptions { unordered: false, ..Default::default() };
-        socket_a.send(Message::new(StreamId(1), PpId(53), vec![0; 2]), &s).unwrap();
-        socket_a.send(Message::new(StreamId(2), PpId(53), vec![0; 2]), &s).unwrap();
-        socket_a.send(Message::new(StreamId(3), PpId(53), vec![0; 2]), &s).unwrap();
+        socket_a.send(Message::new(StreamId(1), PpId(53), zeroed_bytes(2)), &s).unwrap();
+        socket_a.send(Message::new(StreamId(2), PpId(53), zeroed_bytes(2)), &s).unwrap();
+        socket_a.send(Message::new(StreamId(3), PpId(53), zeroed_bytes(2)), &s).unwrap();
 
         let (mut events_a, _) = exchange_packets(&mut socket_a, &mut socket_z);
         expect_no_event!(events_a.pop_front());
@@ -2629,9 +2551,9 @@ mod tests {
         socket_z.get_next_message();
         socket_z.get_next_message();
 
-        socket_a.send(Message::new(StreamId(1), PpId(53), vec![0; 2]), &s).unwrap();
-        socket_a.send(Message::new(StreamId(2), PpId(53), vec![0; 2]), &s).unwrap();
-        socket_a.send(Message::new(StreamId(3), PpId(53), vec![0; 2]), &s).unwrap();
+        socket_a.send(Message::new(StreamId(1), PpId(53), zeroed_bytes(2)), &s).unwrap();
+        socket_a.send(Message::new(StreamId(2), PpId(53), zeroed_bytes(2)), &s).unwrap();
+        socket_a.send(Message::new(StreamId(3), PpId(53), zeroed_bytes(2)), &s).unwrap();
 
         exchange_packets(&mut socket_a, &mut socket_z);
         let msg = socket_z.get_next_message().unwrap();
@@ -2659,14 +2581,13 @@ mod tests {
         connect_sockets(&mut socket_a, &mut socket_z);
 
         socket_a.set_stream_priority(StreamId(1), 0);
-        socket_a
-            .send(Message::new(StreamId(1), PpId(53), vec![1, 2, 3]), &SendOptions::default())
-            .unwrap();
+        let payload = vec![1, 2, 3];
+        socket_a.send(Message::with_payload(payload.clone()), &SendOptions::default()).unwrap();
 
         exchange_packets(&mut socket_a, &mut socket_z);
         let msg = socket_z.get_next_message().unwrap();
         assert_eq!(msg.stream_id, StreamId(1));
-        assert_eq!(msg.payload, vec![1, 2, 3]);
+        assert_eq!(msg.payload, payload);
     }
 
     #[test]
@@ -2693,7 +2614,7 @@ mod tests {
 
         socket_a.set_stream_priority(StreamId(1), 43);
         let s = SendOptions::default();
-        socket_a.send(Message::new(StreamId(1), PpId(51), vec![0; 100]), &s).unwrap();
+        socket_a.send(Message::with_size(100), &s).unwrap();
         socket_a.set_stream_priority(StreamId(2), 34);
 
         exchange_packets(&mut socket_a, &mut socket_z);
@@ -2740,11 +2661,12 @@ mod tests {
         // Enqueue messages before connecting the socket, to ensure they aren't sent as soon as
         // `send` is called.
         let s = SendOptions::default();
-        socket_a.send(Message::new(StreamId(3), PpId(301), vec![0; 10]), &s).unwrap();
-        socket_a.send(Message::new(StreamId(1), PpId(101), vec![0; 10]), &s).unwrap();
-        socket_a.send(Message::new(StreamId(2), PpId(201), vec![0; 10]), &s).unwrap();
-        socket_a.send(Message::new(StreamId(1), PpId(102), vec![0; 10]), &s).unwrap();
-        socket_a.send(Message::new(StreamId(1), PpId(103), vec![0; 10]), &s).unwrap();
+        let payload = zeroed_bytes(10);
+        socket_a.send(Message::new(StreamId(3), PpId(301), payload.clone()), &s).unwrap();
+        socket_a.send(Message::new(StreamId(1), PpId(101), payload.clone()), &s).unwrap();
+        socket_a.send(Message::new(StreamId(2), PpId(201), payload.clone()), &s).unwrap();
+        socket_a.send(Message::new(StreamId(1), PpId(102), payload.clone()), &s).unwrap();
+        socket_a.send(Message::new(StreamId(1), PpId(103), payload.clone()), &s).unwrap();
 
         socket_a.connect();
         exchange_packets(&mut socket_a, &mut socket_z);
@@ -2771,7 +2693,7 @@ mod tests {
         // Enqueue messages before connecting the socket, to ensure they aren't sent as soon as
         // `send` is called.
         let s = SendOptions::default();
-        let payload = vec![0; options.mtu * 2];
+        let payload = zeroed_bytes(options.mtu * 2);
         socket_a.send(Message::new(StreamId(3), PpId(301), payload.clone()), &s).unwrap();
         socket_a.send(Message::new(StreamId(1), PpId(101), payload.clone()), &s).unwrap();
         socket_a.send(Message::new(StreamId(2), PpId(201), payload.clone()), &s).unwrap();
@@ -2798,8 +2720,9 @@ mod tests {
         let mut socket_z = Socket::new("Z", &options);
         connect_sockets(&mut socket_a, &mut socket_z);
 
+        let large_payload = zeroed_bytes(20 * options.mtu);
         socket_a.set_stream_priority(StreamId(2), 128);
-        socket_a.send(Message::new(StreamId(2), PpId(201), vec![0; 20 * options.mtu]), &s).unwrap();
+        socket_a.send(Message::new(StreamId(2), PpId(201), large_payload.clone()), &s).unwrap();
 
         // Due to a non-zero initial congestion window, the message will already start to send, but
         // will not succeed to be sent completely before filling the congestion window or stopping
@@ -2809,8 +2732,8 @@ mod tests {
         // Now enqueue two messages; one small and one large higher priority message.
 
         socket_a.set_stream_priority(StreamId(1), 512);
-        socket_a.send(Message::new(StreamId(1), PpId(101), vec![0; 10]), &s).unwrap();
-        socket_a.send(Message::new(StreamId(1), PpId(102), vec![0; 20 * options.mtu]), &s).unwrap();
+        socket_a.send(Message::new(StreamId(1), PpId(101), zeroed_bytes(10)), &s).unwrap();
+        socket_a.send(Message::new(StreamId(1), PpId(102), large_payload.clone()), &s).unwrap();
 
         exchange_packets(&mut socket_a, &mut socket_z);
 
@@ -2828,21 +2751,17 @@ mod tests {
         let mut socket_z = Socket::new("Z", &options);
         connect_sockets(&mut socket_a, &mut socket_z);
 
+        let payload = zeroed_bytes(options.mtu);
         socket_a
             .send(
-                Message::new(StreamId(1), PpId(101), vec![0; options.mtu]),
+                Message::with_payload(payload.clone()),
                 &SendOptions { lifecycle_id: LifecycleId::new(41), ..Default::default() },
             )
             .unwrap();
+        socket_a.send(Message::with_payload(payload.clone()), &SendOptions::default()).unwrap();
         socket_a
             .send(
-                Message::new(StreamId(1), PpId(102), vec![0; options.mtu]),
-                &SendOptions::default(),
-            )
-            .unwrap();
-        socket_a
-            .send(
-                Message::new(StreamId(1), PpId(103), vec![0; options.mtu]),
+                Message::with_payload(payload.clone()),
                 &SendOptions { lifecycle_id: LifecycleId::new(42), ..Default::default() },
             )
             .unwrap();
@@ -2862,9 +2781,10 @@ mod tests {
         let mut socket_z = Socket::new("Z", &options);
         connect_sockets(&mut socket_a, &mut socket_z);
 
+        let payload = zeroed_bytes(options.mtu - 100);
         socket_a
             .send(
-                Message::new(StreamId(1), PpId(101), vec![0; options.mtu - 100]),
+                Message::with_payload(payload.clone()),
                 &SendOptions {
                     max_retransmissions: Some(0),
                     lifecycle_id: LifecycleId::new(41),
@@ -2874,7 +2794,7 @@ mod tests {
             .unwrap();
         socket_a
             .send(
-                Message::new(StreamId(1), PpId(102), vec![0; options.mtu - 100]),
+                Message::with_payload(payload.clone()),
                 &SendOptions {
                     max_retransmissions: Some(0),
                     lifecycle_id: LifecycleId::new(42),
@@ -2884,7 +2804,7 @@ mod tests {
             .unwrap();
         socket_a
             .send(
-                Message::new(StreamId(1), PpId(103), vec![0; options.mtu - 100]),
+                Message::with_payload(payload.clone()),
                 &SendOptions {
                     max_retransmissions: Some(0),
                     lifecycle_id: LifecycleId::new(43),
@@ -2919,7 +2839,7 @@ mod tests {
 
         socket_a
             .send(
-                Message::new(StreamId(1), PpId(101), vec![0; 20 * options.mtu]),
+                Message::with_size(20 * options.mtu),
                 &SendOptions {
                     max_retransmissions: Some(0),
                     lifecycle_id: LifecycleId::new(41),
@@ -2949,7 +2869,7 @@ mod tests {
         // idea is that it should be expired before even attempting to send it in full.
         socket_a
             .send(
-                Message::new(StreamId(1), PpId(101), vec![0; 20 * options.mtu]),
+                Message::with_size(20 * options.mtu),
                 &SendOptions {
                     lifetime: Some(Duration::from_millis(100)),
                     lifecycle_id: LifecycleId::new(41),
@@ -3001,12 +2921,12 @@ mod tests {
         // Guaranteed to be fragmented into two fragments.
         socket_a
             .send(
-                Message::new(StreamId(1), PpId(53), vec![0; options.mtu + 100]),
+                Message::new(StreamId(1), PpId(53), zeroed_bytes(options.mtu + 100)),
                 &SendOptions::default(),
             )
             .unwrap();
         socket_a
-            .send(Message::new(StreamId(1), PpId(54), vec![0; 100]), &SendOptions::default())
+            .send(Message::new(StreamId(1), PpId(54), zeroed_bytes(100)), &SendOptions::default())
             .unwrap();
 
         socket_a.reset_streams(&[StreamId(1)]).unwrap();
@@ -3070,7 +2990,7 @@ mod tests {
 
         // Send a new message after the stream has been reset.
         socket_a
-            .send(Message::new(StreamId(1), PpId(55), vec![0; 100]), &SendOptions::default())
+            .send(Message::new(StreamId(1), PpId(55), zeroed_bytes(100)), &SendOptions::default())
             .unwrap();
         exchange_packets(&mut socket_a, &mut socket_z);
 
@@ -3088,7 +3008,7 @@ mod tests {
         // Guaranteed to be fragmented into two fragments.
         socket_a
             .send(
-                Message::new(StreamId(1), PpId(51), vec![0; options.mtu + 10]),
+                Message::new(StreamId(1), PpId(51), zeroed_bytes(options.mtu + 10)),
                 &SendOptions::default(),
             )
             .unwrap();
@@ -3096,7 +3016,7 @@ mod tests {
 
         // Will be queued, as the stream has an outstanding reset operation.
         socket_a
-            .send(Message::new(StreamId(1), PpId(52), vec![0; 10]), &SendOptions::default())
+            .send(Message::new(StreamId(1), PpId(52), zeroed_bytes(10)), &SendOptions::default())
             .unwrap();
 
         let (mut events_a, mut events_z) = exchange_packets(&mut socket_a, &mut socket_z);
@@ -3227,9 +3147,7 @@ mod tests {
         let mut socket_z = Socket::new("Z", &options);
         connect_sockets(&mut socket_a, &mut socket_z);
 
-        socket_a
-            .send(Message::new(StreamId(1), PpId(53), vec![1, 2]), &SendOptions::default())
-            .unwrap();
+        socket_a.send(Message::with_size(2), &SendOptions::default()).unwrap();
 
         let packet = expect_sent_packet!(socket_a.poll_event());
         let packet = SctpPacket::from_bytes(&packet, &options).unwrap();
@@ -3247,33 +3165,24 @@ mod tests {
         let mut socket_z = Socket::new("Z", &options);
         connect_sockets(&mut socket_a, &mut socket_z);
 
-        socket_a
-            .send(
-                Message::new(StreamId(1), PpId(53), vec![0; options.mtu * 10]),
-                &SendOptions::default(),
-            )
-            .unwrap();
-        socket_z
-            .send(
-                Message::new(StreamId(1), PpId(53), vec![0; options.mtu * 10]),
-                &SendOptions::default(),
-            )
-            .unwrap();
+        let payload = zeroed_bytes(options.mtu * 10);
+        socket_a.send(Message::with_payload(payload.clone()), &SendOptions::default()).unwrap();
+        socket_z.send(Message::with_payload(payload.clone()), &SendOptions::default()).unwrap();
 
         loop {
             if let Some(e) = socket_a.poll_event() {
-                if let SocketEvent::SendPacket(ref send) = e {
-                    let packet = SctpPacket::from_bytes(send, &options).unwrap();
+                if let SocketEvent::SendPacket(send) = e {
+                    let packet = SctpPacket::from_bytes(&send, &options).unwrap();
                     assert_eq!(packet.common_header.checksum, 0);
-                    socket_z.handle_input(send);
+                    socket_z.handle_input(&send);
                 }
                 continue;
             }
             if let Some(e) = socket_z.poll_event() {
-                if let SocketEvent::SendPacket(ref send) = e {
-                    let packet = SctpPacket::from_bytes(send, &options).unwrap();
+                if let SocketEvent::SendPacket(send) = e {
+                    let packet = SctpPacket::from_bytes(&send, &options).unwrap();
                     assert_eq!(packet.common_header.checksum, 0);
-                    socket_a.handle_input(send);
+                    socket_a.handle_input(&send);
                 }
                 continue;
             }
@@ -3291,7 +3200,7 @@ mod tests {
 
         socket_a
             .send(
-                Message::new(StreamId(1), PpId(51), vec![0; 10]),
+                Message::new(StreamId(1), PpId(51), zeroed_bytes(10)),
                 &SendOptions { max_retransmissions: Some(0), ..SendOptions::default() },
             )
             .unwrap();
@@ -3324,14 +3233,14 @@ mod tests {
 
         // Send two more messages.
         socket_a
-            .send(Message::new(StreamId(1), PpId(52), vec![0; 10]), &SendOptions::default())
+            .send(Message::new(StreamId(1), PpId(52), zeroed_bytes(10)), &SendOptions::default())
             .unwrap();
         socket_a
-            .send(Message::new(StreamId(1), PpId(53), vec![0; 10]), &SendOptions::default())
+            .send(Message::new(StreamId(1), PpId(53), zeroed_bytes(10)), &SendOptions::default())
             .unwrap();
 
         let data_packet = expect_sent_packet!(socket_a.poll_event());
-        socket_z.handle_input(&data_packet);
+        socket_z.handle_input(&data_packet.clone());
         let data_packet = SctpPacket::from_bytes(&data_packet, &options).unwrap();
         let Chunk::Data(c) = &data_packet.chunks[0] else {
             panic!();
@@ -3340,7 +3249,7 @@ mod tests {
         assert_eq!(c.data.ppid, PpId(52));
 
         let data_packet = expect_sent_packet!(socket_a.poll_event());
-        socket_z.handle_input(&data_packet);
+        socket_z.handle_input(&data_packet.clone());
         let data_packet = SctpPacket::from_bytes(&data_packet, &options).unwrap();
         let Chunk::Data(c) = &data_packet.chunks[0] else {
             panic!();
@@ -3390,7 +3299,7 @@ mod tests {
         socket_a.connect();
         // A -> INIT -> Z
         let first_packet = expect_sent_packet!(socket_a.poll_event());
-        socket_z.handle_input(&first_packet);
+        socket_z.handle_input(&first_packet.clone());
         // A <- INIT_ACK <- Z
         let init_ack_packet1 = expect_sent_packet!(socket_z.poll_event());
         expect_no_event!(socket_z.poll_event());
@@ -3416,16 +3325,14 @@ mod tests {
         let mut socket_a = Socket::new("A", &options);
         let mut socket_z = Socket::new("Z", &options);
 
-        let payload: Vec<u8> = vec![0; options.mtu + 20];
-        socket_a
-            .send(Message::new(StreamId(1), PpId(53), payload.clone()), &SendOptions::default())
-            .unwrap();
+        let payload = zeroed_bytes(options.mtu + 20);
+        socket_a.send(Message::with_payload(payload.clone()), &SendOptions::default()).unwrap();
 
         socket_a.connect();
         // A -> INIT -> Z
         let init_packet = expect_sent_packet!(socket_a.poll_event());
         // Extract two INIT-ACKs.
-        socket_z.handle_input(&init_packet);
+        socket_z.handle_input(&init_packet.clone());
         let init_ack_packet1 = expect_sent_packet!(socket_z.poll_event());
         socket_z.handle_input(&init_packet);
         let init_ack_packet2 = expect_sent_packet!(socket_z.poll_event());
@@ -3450,16 +3357,14 @@ mod tests {
         let mut socket_a = Socket::new("A", &options);
         let mut socket_z = Socket::new("Z", &options);
 
-        let payload: Vec<u8> = vec![0; options.mtu + 20];
-        socket_a
-            .send(Message::new(StreamId(1), PpId(53), payload.clone()), &SendOptions::default())
-            .unwrap();
+        let payload = zeroed_bytes(options.mtu + 20);
+        socket_a.send(Message::with_payload(payload.clone()), &SendOptions::default()).unwrap();
 
         socket_a.connect();
         // A -> INIT -> Z
         let init_packet = expect_sent_packet!(socket_a.poll_event());
         // Extract two INIT-ACKs.
-        socket_z.handle_input(&init_packet);
+        socket_z.handle_input(&init_packet.clone());
         let init_ack_packet1 = expect_sent_packet!(socket_z.poll_event());
         socket_z.handle_input(&init_packet);
         let init_ack_packet2 = expect_sent_packet!(socket_z.poll_event());
@@ -3609,7 +3514,7 @@ mod tests {
 
         // Z should have received the message
         let msg = socket_z.get_next_message().unwrap();
-        assert_eq!(msg.payload, b"hello");
+        assert_eq!(&msg.payload[..], b"hello");
     }
 
     #[test]
@@ -3622,9 +3527,7 @@ mod tests {
 
         // Send a message from A to Z. This will be the first packet, which will trigger an
         // immediate SACK.
-        socket_a
-            .send(Message::new(StreamId(1), PpId(1), b"hello".to_vec()), &SendOptions::default())
-            .unwrap();
+        socket_a.send(Message::with_size(5), &SendOptions::default()).unwrap();
 
         let packet = expect_sent_packet!(socket_a.poll_event());
         socket_z.handle_input(&packet);
@@ -3635,9 +3538,7 @@ mod tests {
 
         // Send a second message from A to Z. This will be the second packet, which should trigger
         // a delayed SACK.
-        socket_a
-            .send(Message::new(StreamId(1), PpId(1), b"hello".to_vec()), &SendOptions::default())
-            .unwrap();
+        socket_a.send(Message::with_size(5), &SendOptions::default()).unwrap();
         let packet = expect_sent_packet!(socket_a.poll_event());
 
         socket_z.handle_input(&packet);

--- a/src/socket/stream_reset.rs
+++ b/src/socket/stream_reset.rs
@@ -561,8 +561,8 @@ mod tests {
         tcb.data_tracker.observe(SocketTime::zero(), Tsn(11), false);
         tcb.reassembly_queue.add(Tsn(11), seq.ordered("2345", "BE"));
 
-        assert_eq!(tcb.reassembly_queue.get_next_message().unwrap().payload, b"1234");
-        assert_eq!(tcb.reassembly_queue.get_next_message().unwrap().payload, b"2345");
+        assert_eq!(tcb.reassembly_queue.get_next_message().unwrap().payload.as_ref(), b"1234");
+        assert_eq!(tcb.reassembly_queue.get_next_message().unwrap().payload.as_ref(), b"2345");
         assert!(tcb.reassembly_queue.get_next_message().is_none());
 
         // Simulate sender resetting the stream (SSN reset to 0) but receiver NOT processing it.
@@ -589,8 +589,8 @@ mod tests {
         tcb.data_tracker.observe(SocketTime::zero(), Tsn(11), false);
         tcb.reassembly_queue.add(Tsn(11), seq.ordered("2345", "BE"));
 
-        assert_eq!(tcb.reassembly_queue.get_next_message().unwrap().payload, b"1234");
-        assert_eq!(tcb.reassembly_queue.get_next_message().unwrap().payload, b"2345");
+        assert_eq!(tcb.reassembly_queue.get_next_message().unwrap().payload.as_ref(), b"1234");
+        assert_eq!(tcb.reassembly_queue.get_next_message().unwrap().payload.as_ref(), b"2345");
         assert!(tcb.reassembly_queue.get_next_message().is_none());
 
         // Reset, SID=1, TSN=11 (fulfilled).
@@ -622,7 +622,7 @@ mod tests {
         tcb.data_tracker.observe(SocketTime::zero(), Tsn(12), false);
         tcb.reassembly_queue.add(Tsn(12), seq.ordered("3456", "BE"));
 
-        assert_eq!(tcb.reassembly_queue.get_next_message().unwrap().payload, b"3456");
+        assert_eq!(tcb.reassembly_queue.get_next_message().unwrap().payload.as_ref(), b"3456");
     }
 
     #[test]
@@ -658,7 +658,11 @@ mod tests {
         let response = expect_sent_reconfig_response(&events, &ctx.options);
         assert_eq!(response.result, ReconfigurationResponseResult::InProgress);
 
-        while let Some(event) = events.borrow_mut().next_event() {
+        loop {
+            let event = events.borrow_mut().next_event();
+            let Some(event) = event else {
+                break;
+            };
             if let SocketEvent::OnIncomingStreamReset(_) = event {
                 panic!("Unexpected OnIncomingStreamReset event: {:?}", event);
             }
@@ -701,9 +705,9 @@ mod tests {
         tcb.data_tracker.observe(SocketTime::zero(), Tsn(12), false);
         tcb.reassembly_queue.add(Tsn(12), seq.ordered("3456", "BE"));
 
-        assert_eq!(tcb.reassembly_queue.get_next_message().unwrap().payload, b"1234"); // TSN=10
-        assert_eq!(tcb.reassembly_queue.get_next_message().unwrap().payload, b"2345"); // TSN=11
-        assert_eq!(tcb.reassembly_queue.get_next_message().unwrap().payload, b"3456");
+        assert_eq!(tcb.reassembly_queue.get_next_message().unwrap().payload.as_ref(), b"1234"); // TSN=10
+        assert_eq!(tcb.reassembly_queue.get_next_message().unwrap().payload.as_ref(), b"2345"); // TSN=11
+        assert_eq!(tcb.reassembly_queue.get_next_message().unwrap().payload.as_ref(), b"3456");
     }
 
     #[test]
@@ -743,17 +747,17 @@ mod tests {
         // TSN 10, SID 1 - before TSN 12 -> deliver
         tcb.data_tracker.observe(SocketTime::zero(), Tsn(10), false);
         tcb.reassembly_queue.add(Tsn(10), seq1.ordered("1111", "BE"));
-        assert_eq!(tcb.reassembly_queue.get_next_message().unwrap().payload, b"1111");
+        assert_eq!(tcb.reassembly_queue.get_next_message().unwrap().payload.as_ref(), b"1111");
 
         // TSN 11, SID 2 - before TSN 12 -> deliver
         tcb.data_tracker.observe(SocketTime::zero(), Tsn(11), false);
         tcb.reassembly_queue.add(Tsn(11), seq2.ordered("2222", "BE"));
-        assert_eq!(tcb.reassembly_queue.get_next_message().unwrap().payload, b"2222");
+        assert_eq!(tcb.reassembly_queue.get_next_message().unwrap().payload.as_ref(), b"2222");
 
         // TSN 12, SID 3 - at TSN 12 -> deliver
         tcb.data_tracker.observe(SocketTime::zero(), Tsn(12), false);
         tcb.reassembly_queue.add(Tsn(12), seq3.ordered("3333", "BE"));
-        assert_eq!(tcb.reassembly_queue.get_next_message().unwrap().payload, b"3333");
+        assert_eq!(tcb.reassembly_queue.get_next_message().unwrap().payload.as_ref(), b"3333");
 
         // TSN 13, SID 1 - after TSN 12 and SID=1 -> defer
         let mut seq1 = DataSequencer::new(StreamId(1));
@@ -770,7 +774,7 @@ mod tests {
         // TSN 15, SID 3 - after TSN 12, but SID 3 is not reset -> deliver
         tcb.data_tracker.observe(SocketTime::zero(), Tsn(15), false);
         tcb.reassembly_queue.add(Tsn(15), seq3.ordered("4444", "BE"));
-        assert_eq!(tcb.reassembly_queue.get_next_message().unwrap().payload, b"4444");
+        assert_eq!(tcb.reassembly_queue.get_next_message().unwrap().payload.as_ref(), b"4444");
 
         // Process request again (TSN=12 is received, this can be performed.)
         handle_reconfig(
@@ -796,8 +800,8 @@ mod tests {
 
         // The deferred messages from SID=1 and SID=2 can now be delivered.
         let tcb = state.tcb_mut().unwrap();
-        assert_eq!(tcb.reassembly_queue.get_next_message().unwrap().payload, b"1-new");
-        assert_eq!(tcb.reassembly_queue.get_next_message().unwrap().payload, b"2-new");
+        assert_eq!(tcb.reassembly_queue.get_next_message().unwrap().payload.as_ref(), b"1-new");
+        assert_eq!(tcb.reassembly_queue.get_next_message().unwrap().payload.as_ref(), b"2-new");
         assert!(tcb.reassembly_queue.get_next_message().is_none());
     }
 
@@ -902,7 +906,7 @@ mod tests {
         let tcb = state.tcb_mut().unwrap();
         // Expect TSN 15 (SSN 1) to be delivered.
         // TSN 13+14 (SSN 0) was skipped via ForwardTSN.
-        assert_eq!(tcb.reassembly_queue.get_next_message().unwrap().payload, b"next");
+        assert_eq!(tcb.reassembly_queue.get_next_message().unwrap().payload.as_ref(), b"next");
         assert!(tcb.reassembly_queue.get_next_message().is_none());
     }
 
@@ -945,7 +949,7 @@ mod tests {
         let large_payload = vec![0u8; 2000];
         ctx.send_queue.add(
             SocketTime::zero(),
-            Message::new(StreamId(42), PpId(53), large_payload),
+            Message::new(StreamId(42), PpId(53), large_payload.into()),
             &SendOptions::default(),
         );
 
@@ -958,7 +962,11 @@ mod tests {
         do_reset_streams(&mut state, &mut ctx, SocketTime::zero(), &[StreamId(42)]).unwrap();
 
         // Should NOT send a request yet because stream is pending (has partially sent data).
-        while let Some(event) = events.borrow_mut().next_event() {
+        loop {
+            let event = events.borrow_mut().next_event();
+            let Some(event) = event else {
+                break;
+            };
             if let SocketEvent::SendPacket(packet) = event {
                 let packet = SctpPacket::from_bytes(&packet, &ctx.options).unwrap();
                 if packet.chunks.iter().any(|c| matches!(c, Chunk::ReConfig(_))) {
@@ -1081,7 +1089,11 @@ mod tests {
         );
 
         // Should NOT trigger any new reconfig packet immediately. Drain events to be sure.
-        while let Some(event) = events.borrow_mut().next_event() {
+        loop {
+            let event = events.borrow_mut().next_event();
+            let Some(event) = event else {
+                break;
+            };
             if let SocketEvent::SendPacket(packet) = event {
                 let packet = SctpPacket::from_bytes(&packet, &ctx.options).unwrap();
                 if packet.chunks.iter().any(|c| matches!(c, Chunk::ReConfig(_))) {
@@ -1122,7 +1134,11 @@ mod tests {
 
         // Try to send packets. Should NOT produce new ReConfig (because one is in flight).
         ctx.send_buffered_packets(&mut state, SocketTime::zero());
-        while let Some(event) = events.borrow_mut().next_event() {
+        loop {
+            let event = events.borrow_mut().next_event();
+            let Some(event) = event else {
+                break;
+            };
             if let SocketEvent::SendPacket(packet) = event {
                 let packet = SctpPacket::from_bytes(&packet, &ctx.options).unwrap();
                 if packet.chunks.iter().any(|c| matches!(c, Chunk::ReConfig(_))) {
@@ -1582,7 +1598,11 @@ mod tests {
             ReconfigurationResponseResult::SuccessPerformed
         );
         // Should NOT trigger event again.
-        while let Some(event) = events.borrow_mut().next_event() {
+        loop {
+            let event = events.borrow_mut().next_event();
+            let Some(event) = event else {
+                break;
+            };
             if let SocketEvent::OnIncomingStreamReset(_) = event {
                 panic!("Unexpected OnIncomingStreamReset event: {:?}", event);
             }

--- a/src/socket/stream_reset.rs
+++ b/src/socket/stream_reset.rs
@@ -417,7 +417,7 @@ mod tests {
             let event = events.borrow_mut().next_event().expect("expected event");
             match event {
                 SocketEvent::SendPacket(packet) => {
-                    return SctpPacket::from_bytes(&packet, options).expect("valid packet");
+                    return SctpPacket::from_bytes(packet, options).expect("valid packet");
                 }
                 SocketEvent::OnBufferedAmountLow(_) => {
                     // Ignore these - handling them explicitly in the tests just create noise.
@@ -434,8 +434,7 @@ mod tests {
         events: &Rc<RefCell<Events>>,
         options: &Options,
     ) -> ReConfigChunk {
-        let packet = expect_sent_packet(events, options);
-        packet
+        expect_sent_packet(events, options)
             .chunks
             .into_iter()
             .find_map(|c| match c {
@@ -968,7 +967,7 @@ mod tests {
                 break;
             };
             if let SocketEvent::SendPacket(packet) = event {
-                let packet = SctpPacket::from_bytes(&packet, &ctx.options).unwrap();
+                let packet = SctpPacket::from_bytes(packet, &ctx.options).unwrap();
                 if packet.chunks.iter().any(|c| matches!(c, Chunk::ReConfig(_))) {
                     panic!("Unexpected ReConfig chunk - should be deferred");
                 }
@@ -1095,7 +1094,7 @@ mod tests {
                 break;
             };
             if let SocketEvent::SendPacket(packet) = event {
-                let packet = SctpPacket::from_bytes(&packet, &ctx.options).unwrap();
+                let packet = SctpPacket::from_bytes(packet, &ctx.options).unwrap();
                 if packet.chunks.iter().any(|c| matches!(c, Chunk::ReConfig(_))) {
                     panic!("Unexpected ReConfig chunk");
                 }
@@ -1140,7 +1139,7 @@ mod tests {
                 break;
             };
             if let SocketEvent::SendPacket(packet) = event {
-                let packet = SctpPacket::from_bytes(&packet, &ctx.options).unwrap();
+                let packet = SctpPacket::from_bytes(packet, &ctx.options).unwrap();
                 if packet.chunks.iter().any(|c| matches!(c, Chunk::ReConfig(_))) {
                     panic!("Unexpected ReConfig chunk");
                 }

--- a/src/testing/data_sequencer.rs
+++ b/src/testing/data_sequencer.rs
@@ -44,7 +44,7 @@ impl DataSequencer {
             mid: self.message_id,
             fsn: self.fsn,
             ppid: PpId(53),
-            payload: payload.as_bytes().to_vec(),
+            payload: payload.as_bytes().to_vec().into(),
             is_beginning,
             is_end,
         };
@@ -68,7 +68,7 @@ impl DataSequencer {
             mid: self.message_id,
             fsn: self.fsn,
             ppid: PpId(53),
-            payload: payload.as_bytes().to_vec(),
+            payload: payload.as_bytes().to_vec().into(),
             is_beginning,
             is_end,
         };

--- a/src/tx/retransmission_queue.rs
+++ b/src/tx/retransmission_queue.rs
@@ -562,10 +562,11 @@ impl RetransmissionQueue {
         while max_bytes > self.data_chunk_header_size {
             debug_assert!(is_divisible_by_4!(max_bytes));
 
-            if let Some(chunk) = produce(
+            let chunk = produce(
                 max_bytes - self.data_chunk_header_size,
                 &self.outstanding_data.get_unsent_messages_to_discard(),
-            ) {
+            );
+            if let Some(chunk) = chunk {
                 let chunk_size =
                     round_up_to_4!(self.data_chunk_header_size + chunk.data.payload.len());
                 max_bytes -= chunk_size;

--- a/src/tx/retransmission_queue.rs
+++ b/src/tx/retransmission_queue.rs
@@ -793,7 +793,7 @@ mod tests {
     fn add_message(sq: &mut SendQueue, now: SocketTime) {
         sq.add(
             now,
-            Message::new(StreamId(1), PpId(53), vec![1, 2, 4, 5, 6]),
+            Message::new(StreamId(1), PpId(53), vec![1, 2, 4, 5, 6].into()),
             &SendOptions::default(),
         );
     }
@@ -1256,7 +1256,7 @@ mod tests {
 
         sq.add(
             now,
-            Message::new(StreamId(1), PpId(53), vec![1, 2, 4, 5, 6]),
+            Message::new(StreamId(1), PpId(53), vec![1, 2, 4, 5, 6].into()),
             &SendOptions { max_retransmissions: Some(0), ..SendOptions::default() },
         );
 
@@ -1290,7 +1290,7 @@ mod tests {
 
         sq.add(
             now,
-            Message::new(StreamId(1), PpId(53), vec![1, 2, 4, 5, 6]),
+            Message::new(StreamId(1), PpId(53), vec![1, 2, 4, 5, 6].into()),
             &SendOptions { max_retransmissions: Some(0), ..SendOptions::default() },
         );
 
@@ -1325,7 +1325,7 @@ mod tests {
 
         sq.add(
             now,
-            Message::new(StreamId(1), PpId(53), vec![1, 2, 4, 5, 6]),
+            Message::new(StreamId(1), PpId(53), vec![1, 2, 4, 5, 6].into()),
             &SendOptions { max_retransmissions: Some(3), ..SendOptions::default() },
         );
 
@@ -1391,7 +1391,7 @@ mod tests {
 
         sq.add(
             now,
-            Message::new(StreamId(1), PpId(53), vec![0; 1000]),
+            Message::new(StreamId(1), PpId(53), vec![0; 1000].into()),
             &SendOptions { max_retransmissions: Some(3), ..SendOptions::default() },
         );
 
@@ -1434,7 +1434,7 @@ mod tests {
 
         sq.add(
             now,
-            Message::new(StreamId(1), PpId(53), vec![0; 4 * 4]),
+            Message::new(StreamId(1), PpId(53), vec![0; 4 * 4].into()),
             &SendOptions { max_retransmissions: Some(0), ..SendOptions::default() },
         );
 
@@ -1494,7 +1494,7 @@ mod tests {
 
         sq.add(
             now,
-            Message::new(StreamId(1), PpId(53), vec![0; 3 * 4]),
+            Message::new(StreamId(1), PpId(53), vec![0; 3 * 4].into()),
             &SendOptions { max_retransmissions: Some(0), ..SendOptions::default() },
         );
 
@@ -1560,10 +1560,10 @@ mod tests {
         sq.set_priority(StreamId(2), 1);
         sq.set_priority(StreamId(3), 1);
         sq.set_priority(StreamId(4), 1);
-        sq.add(now, Message::new(StreamId(1), PpId(53), vec![0; 2 * MTU]), &s);
-        sq.add(now, Message::new(StreamId(2), PpId(53), vec![0; 2 * MTU]), &s);
-        sq.add(now, Message::new(StreamId(3), PpId(53), vec![0; 2 * MTU]), &s);
-        sq.add(now, Message::new(StreamId(4), PpId(53), vec![0; 2 * MTU]), &s);
+        sq.add(now, Message::new(StreamId(1), PpId(53), vec![0; 2 * MTU].into()), &s);
+        sq.add(now, Message::new(StreamId(2), PpId(53), vec![0; 2 * MTU].into()), &s);
+        sq.add(now, Message::new(StreamId(3), PpId(53), vec![0; 2 * MTU].into()), &s);
+        sq.add(now, Message::new(StreamId(4), PpId(53), vec![0; 2 * MTU].into()), &s);
 
         let bytes = MTU;
         assert_eq!(
@@ -1725,7 +1725,11 @@ mod tests {
         let mut sq = SendQueue::new(MTU, &Options::default(), events.clone());
         let mut rtx = create_queue(/* supports_partial_reliability */ true, false, events);
 
-        sq.add(now, Message::new(StreamId(1), PpId(53), vec![0; 4 * 8]), &SendOptions::default());
+        sq.add(
+            now,
+            Message::new(StreamId(1), PpId(53), vec![0; 4 * 8].into()),
+            &SendOptions::default(),
+        );
 
         for _ in 0..8 {
             rtx.get_chunks_to_send(now, data_chunk::HEADER_SIZE + 4, |bytes, _| {
@@ -1877,12 +1881,12 @@ mod tests {
 
         sq.add(
             now,
-            Message::new(StreamId(1), PpId(53), vec![0; FIRST_DATA_PAYLOAD_SIZE]),
+            Message::new(StreamId(1), PpId(53), vec![0; FIRST_DATA_PAYLOAD_SIZE].into()),
             &SendOptions::default(),
         );
         sq.add(
             now,
-            Message::new(StreamId(1), PpId(53), vec![0; SECOND_DATA_PAYLOAD_SIZE]),
+            Message::new(StreamId(1), PpId(53), vec![0; SECOND_DATA_PAYLOAD_SIZE].into()),
             &SendOptions::default(),
         );
 
@@ -1912,7 +1916,7 @@ mod tests {
 
         sq.add(
             now,
-            Message::new(StreamId(1), PpId(53), vec![0; 16]),
+            Message::new(StreamId(1), PpId(53), vec![0; 16].into()),
             &SendOptions { max_retransmissions: Some(0), ..SendOptions::default() },
         );
 
@@ -2005,7 +2009,7 @@ mod tests {
 
         sq.add(
             now,
-            Message::new(StreamId(1), PpId(53), vec![0; 16]),
+            Message::new(StreamId(1), PpId(53), vec![0; 16].into()),
             &SendOptions { max_retransmissions: Some(0), ..SendOptions::default() },
         );
 
@@ -2070,12 +2074,12 @@ mod tests {
         sq.set_priority(StreamId(2), 1);
         sq.add(
             now,
-            Message::new(StreamId(1), PpId(53), vec![0; MAX_SIZE_IN_FRAGMENT * 2]),
+            Message::new(StreamId(1), PpId(53), vec![0; MAX_SIZE_IN_FRAGMENT * 2].into()),
             &SendOptions { max_retransmissions: Some(0), ..SendOptions::default() },
         );
         sq.add(
             now,
-            Message::new(StreamId(2), PpId(54), vec![0; MAX_SIZE_IN_FRAGMENT * 2]),
+            Message::new(StreamId(2), PpId(54), vec![0; MAX_SIZE_IN_FRAGMENT * 2].into()),
             &SendOptions::default(),
         );
 
@@ -2140,12 +2144,12 @@ mod tests {
         sq.set_priority(StreamId(2), 1);
         sq.add(
             now,
-            Message::new(StreamId(1), PpId(53), vec![0; MAX_SIZE_IN_FRAGMENT * 2]),
+            Message::new(StreamId(1), PpId(53), vec![0; MAX_SIZE_IN_FRAGMENT * 2].into()),
             &SendOptions { max_retransmissions: Some(0), ..SendOptions::default() },
         );
         sq.add(
             now,
-            Message::new(StreamId(2), PpId(54), vec![0; MAX_SIZE_IN_FRAGMENT * 2]),
+            Message::new(StreamId(2), PpId(54), vec![0; MAX_SIZE_IN_FRAGMENT * 2].into()),
             &SendOptions { max_retransmissions: Some(0), ..SendOptions::default() },
         );
 
@@ -2206,7 +2210,7 @@ mod tests {
         for _ in 0..8 {
             sq.add(
                 now,
-                Message::new(StreamId(1), PpId(53), vec![0; 4]),
+                Message::new(StreamId(1), PpId(53), vec![0; 4].into()),
                 &SendOptions { max_retransmissions: Some(0), ..SendOptions::default() },
             );
         }
@@ -2287,7 +2291,7 @@ mod tests {
         for _ in 0..10 {
             sq.add(
                 now,
-                Message::new(StreamId(1), PpId(53), vec![0; 4]),
+                Message::new(StreamId(1), PpId(53), vec![0; 4].into()),
                 &SendOptions { max_retransmissions: Some(2), ..SendOptions::default() },
             );
         }
@@ -2359,7 +2363,7 @@ mod tests {
 
         sq.add(
             now,
-            Message::new(StreamId(1), PpId(53), vec![0; 1000]),
+            Message::new(StreamId(1), PpId(53), vec![0; 1000].into()),
             &SendOptions { max_retransmissions: Some(3), ..SendOptions::default() },
         );
 
@@ -2557,7 +2561,7 @@ mod tests {
         for tsn in 10..=14 {
             sq.add(
                 now,
-                Message::new(StreamId(1), PpId(53), vec![0; MAX_SIZE_IN_FRAGMENT]),
+                Message::new(StreamId(1), PpId(53), vec![0; MAX_SIZE_IN_FRAGMENT].into()),
                 &SendOptions::default(),
             );
             assert_eq!(
@@ -2677,7 +2681,11 @@ mod tests {
         );
 
         // Add a message
-        sq.add(now, Message::new(StreamId(1), PpId(53), vec![1, 2, 3]), &SendOptions::default());
+        sq.add(
+            now,
+            Message::new(StreamId(1), PpId(53), vec![1, 2, 3].into()),
+            &SendOptions::default(),
+        );
 
         // Try to send. Should send one chunk as a probe.
         let chunks = rtx.get_chunks_to_send(now, MTU, |bytes, _| sq.produce(now, bytes));
@@ -2695,7 +2703,7 @@ mod tests {
 
         sq.add(
             now,
-            Message::new(StreamId(1), PpId(53), vec![0; 100]),
+            Message::new(StreamId(1), PpId(53), vec![0; 100].into()),
             &SendOptions { lifecycle_id: LifecycleId::new(1), ..SendOptions::default() },
         );
 
@@ -2721,7 +2729,7 @@ mod tests {
         // Add a message, produce it in full and drain any event.
         sq.add(
             now,
-            Message::new(StreamId(1), PpId(53), vec![0; 100]),
+            Message::new(StreamId(1), PpId(53), vec![0; 100].into()),
             &SendOptions { lifecycle_id: LifecycleId::new(1), ..SendOptions::default() },
         );
         rtx.get_chunks_to_send(now, MTU, |bytes, _| sq.produce(now, bytes));
@@ -2754,7 +2762,7 @@ mod tests {
         // Add a message (with expiration), produce it in full and drain any event.
         sq.add(
             now,
-            Message::new(StreamId(1), PpId(53), vec![0; 100]),
+            Message::new(StreamId(1), PpId(53), vec![0; 100].into()),
             &SendOptions {
                 lifecycle_id: LifecycleId::new(1),
                 max_retransmissions: Some(0),

--- a/src/tx/send_queue.rs
+++ b/src/tx/send_queue.rs
@@ -634,7 +634,11 @@ mod tests {
     }
 
     fn add(q: &mut SendQueue, sid: StreamId, ppid: PpId, payload: Vec<u8>) {
-        q.add(START_TIME, Message::new(sid, ppid, payload), &SendOptions { ..Default::default() });
+        q.add(
+            START_TIME,
+            Message::new(sid, ppid, payload.into()),
+            &SendOptions { ..Default::default() },
+        );
     }
 
     #[test]
@@ -731,7 +735,7 @@ mod tests {
         let now = START_TIME;
         q.add(
             now,
-            Message::new(StreamId(1), PpId(54), vec![0; 100]),
+            Message::new(StreamId(1), PpId(54), vec![0; 100].into()),
             &SendOptions {
                 lifetime: Some(Duration::from_millis(1000)),
                 lifecycle_id: LifecycleId::new(1),
@@ -760,7 +764,7 @@ mod tests {
 
         q.add(
             START_TIME,
-            Message::new(StreamId(1), PpId(54), vec![0; 20]),
+            Message::new(StreamId(1), PpId(54), vec![0; 20].into()),
             &SendOptions { unordered: true, ..Default::default() },
         );
 
@@ -779,7 +783,7 @@ mod tests {
         // Default is no expiry
         q.add(
             now,
-            Message::new(StreamId(1), PpId(50), vec![0; 20]),
+            Message::new(StreamId(1), PpId(50), vec![0; 20].into()),
             &SendOptions { ..Default::default() },
         );
         assert!(q.produce(now, 100).is_some());
@@ -787,7 +791,7 @@ mod tests {
         // Add and consume within lifetime
         q.add(
             now,
-            Message::new(StreamId(1), PpId(50), vec![0; 20]),
+            Message::new(StreamId(1), PpId(50), vec![0; 20].into()),
             &SendOptions { lifetime: Some(Duration::from_secs(2)), ..Default::default() },
         );
         now = now + Duration::from_secs(2);
@@ -796,7 +800,7 @@ mod tests {
         // Add and consume just outside lifetime
         q.add(
             now,
-            Message::new(StreamId(1), PpId(50), vec![0; 20]),
+            Message::new(StreamId(1), PpId(50), vec![0; 20].into()),
             &SendOptions { lifetime: Some(Duration::from_secs(2)), ..Default::default() },
         );
         now = now + Duration::from_millis(2001);
@@ -805,7 +809,7 @@ mod tests {
         // A long time after expiry.
         q.add(
             now,
-            Message::new(StreamId(1), PpId(50), vec![0; 20]),
+            Message::new(StreamId(1), PpId(50), vec![0; 20].into()),
             &SendOptions { lifetime: Some(Duration::from_secs(2)), ..Default::default() },
         );
         now = now + Duration::from_secs(1000);
@@ -814,12 +818,12 @@ mod tests {
         // Expire one message, but produce the second that is not expired.
         q.add(
             now,
-            Message::new(StreamId(1), PpId(50), vec![0; 20]),
+            Message::new(StreamId(1), PpId(50), vec![0; 20].into()),
             &SendOptions { lifetime: Some(Duration::from_secs(2)), ..Default::default() },
         );
         q.add(
             now,
-            Message::new(StreamId(1), PpId(51), vec![0; 20]),
+            Message::new(StreamId(1), PpId(51), vec![0; 20].into()),
             &SendOptions { lifetime: Some(Duration::from_secs(4)), ..Default::default() },
         );
         now = now + Duration::from_millis(2001);
@@ -1468,7 +1472,7 @@ mod tests {
         let now = START_TIME;
         q.add(
             now,
-            Message::new(StreamId(1), PpId(54), vec![0; 20]),
+            Message::new(StreamId(1), PpId(54), vec![0; 20].into()),
             &SendOptions {
                 lifetime: Some(Duration::from_millis(1000)),
                 lifecycle_id: LifecycleId::new(1),
@@ -1494,12 +1498,12 @@ mod tests {
         let now = START_TIME;
         q.add(
             now,
-            Message::new(StreamId(1), PPID, vec![0; 120]),
+            Message::new(StreamId(1), PPID, vec![0; 120].into()),
             &SendOptions { lifecycle_id: LifecycleId::new(1), ..Default::default() },
         );
         q.add(
             now,
-            Message::new(StreamId(1), PPID, vec![0; 120]),
+            Message::new(StreamId(1), PPID, vec![0; 120].into()),
             &SendOptions { lifecycle_id: LifecycleId::new(2), ..Default::default() },
         );
 
@@ -1526,7 +1530,7 @@ mod tests {
         let now = START_TIME;
         q.add(
             now,
-            Message::new(StreamId(1), PPID, vec![0; 120]),
+            Message::new(StreamId(1), PPID, vec![0; 120].into()),
             &SendOptions { lifecycle_id: LifecycleId::new(1), ..Default::default() },
         );
 
@@ -1549,7 +1553,7 @@ mod tests {
 
         q.add(
             START_TIME,
-            Message::new(StreamId(1), PpId(53), vec![0; 100]),
+            Message::new(StreamId(1), PpId(53), vec![0; 100].into()),
             &SendOptions::default(),
         );
 
@@ -1572,7 +1576,7 @@ mod tests {
         // On the restored queue, consuming a new message should yield the next ssn.
         q2.add(
             START_TIME,
-            Message::new(StreamId(1), PpId(53), vec![0; 100]),
+            Message::new(StreamId(1), PpId(53), vec![0; 100].into()),
             &SendOptions::default(),
         );
 

--- a/src/tx/send_queue.rs
+++ b/src/tx/send_queue.rs
@@ -332,12 +332,8 @@ impl SendQueue {
         let fsn = item.current_fsn;
         let lifecycle_id = if is_end { item.attributes.lifecycle_id.clone() } else { None };
         item.current_fsn += 1;
-        let payload = item
-            .message
-            .payload
-            .get(item.remaining_offset..size + item.remaining_offset)
-            .unwrap()
-            .to_vec();
+        let payload =
+            item.message.payload.slice(item.remaining_offset..size + item.remaining_offset);
         self.buffered_amount -= payload.len();
         stream.buffered_amount -= payload.len();
 
@@ -347,7 +343,7 @@ impl SendQueue {
             mid: item.mid.unwrap(),
             fsn,
             ppid: item.message.ppid,
-            payload,
+            payload: payload.to_vec(),
             is_beginning,
             is_end,
         };

--- a/src/tx/send_queue.rs
+++ b/src/tx/send_queue.rs
@@ -343,7 +343,7 @@ impl SendQueue {
             mid: item.mid.unwrap(),
             fsn,
             ppid: item.message.ppid,
-            payload: payload.to_vec(),
+            payload,
             is_beginning,
             is_end,
         };


### PR DESCRIPTION
bytes::Bytes is quite similar to rtc::CopyOnWriteBuffer, and the de-facto library used by network libraries.

This is efficient both on the sending side - a single large message can be fragmented, and each fragment (e.g. in the retransmission queue) doesn't need to be copied many times, but just sliced into fragments, and each fragment is backed by a (reference counted) backing storage. And also on the packet layer when receiving, as received packets which carry DATA payloads can have that payload sliced and put into the reassembly queue, without causing copies.

One should however be careful, as Bytes is thread safe, slicing/copying it has a non-trivial cost and the packet parsing has been adapted to not cause unnecessary copies/slicing. 

Some code refactoring was necessary to please the compiler (drop order changing in Rust 2024 etc...)

Please read the commit message as it explains this a bit further.

NOTE: This doesn't affect the FFI interface.