### PR TITLE
Handle OutstandingData serial arithmetic wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
  - Align sender and receiver to signal advertised receiver window size as
    payload bytes, excluding any headers.
+ - Support receiving invalid SACKs causing serial number arithmetic wrapping.
 
 ## 0.1.11 - 2026-04-08
 

--- a/src/tx/outstanding_data.rs
+++ b/src/tx/outstanding_data.rs
@@ -408,8 +408,10 @@ impl OutstandingData {
         for block in gap_ack_blocks {
             let cur_block_first_acked = cumulative_tsn_ack.add_to(block.start as u32);
             let mut tsn = prev_block_last_acked.max(self.last_cumulative_tsn_ack) + 1;
-            let limit = cur_block_first_acked.min(self.next_tsn());
-            while tsn < limit && tsn <= max_tsn_to_nack {
+            let limit = self.next_tsn();
+            // TSN comparisons lack transitivity; each upper bound must be evaluated individually to
+            // safely handle serial arithmetic wrapping.
+            while tsn < cur_block_first_acked && tsn <= max_tsn_to_nack && tsn < limit {
                 ack_info.has_packet_loss |= self.nack_chunk(tsn, false, !is_in_fast_recovery);
                 tsn += 1;
             }
@@ -2020,5 +2022,14 @@ mod tests {
         // Assume a valid (but old) SACK is received, acking TSN 5, 15.
         let gab = vec![GapAckBlock::new(10, 10)];
         buf.handle_sack(Tsn(5), &gab, false);
+    }
+
+    #[test]
+    fn test_malformed_sack_does_not_panic() {
+        let mut buf = OutstandingData::new(DATA_CHUNK_HEADER_SIZE, Tsn(u32::MAX));
+
+        // This shouldn't panic.
+        let is_in_fast_recovery = true;
+        buf.handle_sack(Tsn(u32::MAX / 2 - 1), &[GapAckBlock::new(2, 2)], is_in_fast_recovery);
     }
 }


### PR DESCRIPTION
The `nack_between_ack_blocks` function could call `nack_chunk` with invalid TSNs (TSNs not present in the outstanding_data queue), which would lead to a panic.

The loop limit was calculated as `cur_block_first_acked.min(self.next_tsn())` using serial number arithmetic. If a peer sends a malformed SACK with a gap block starting at a TSN very far ahead (or wrapped), `cur_block_first_acked` can be considered "less than" `next_tsn()` in serial number arithmetic, even though it is numerically much larger and represents data never sent.

For example, if `last_cumulative_tsn_ack` is `u32::MAX` `and next_tsn()` is `0`, a gap block starting at `u32::MAX/2 + 1` will result in `cur_block_first_acked` being `u32::MAX / 2 + 1`. In serial number arithmetic, `u32::MAX/2 + 1` is considered less than `0` (as the distance is less than `2^31`). So min returns `u32::MAX / 2 + 1` instead of `0`, which would iterate over invalid TSNs.

This was found by fuzzing.