### PR TITLE
Add and configure outstanding data fuzzer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,11 @@ jobs:
           toolchain: nightly
       - run: |
           cargo install cargo-fuzz
-          cargo fuzz run parse_parameters -- -max_total_time=5
-          cargo fuzz run parse_error_causes -- -max_total_time=5
-          cargo fuzz run parse_packet -- -max_total_time=5
+          cargo fuzz build
+          cargo fuzz run parse_parameters -- -max_total_time=10 -timeout=1 -max_len=200
+          cargo fuzz run parse_error_causes -- -max_total_time=10 -timeout=1 -max_len=200
+          cargo fuzz run parse_packet -- -max_total_time=10 -timeout=1 -max_len=200
+          cargo fuzz run fuzz_outstanding_data -- -max_total_time=10 -timeout=1 -max_len=200
 
   check-rustfmt:
     name: Check (rustfmt)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,9 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "cc"
@@ -135,6 +138,7 @@ dependencies = [
 name = "dcsctp"
 version = "0.1.12"
 dependencies = [
+ "arbitrary",
  "cxx",
  "cxx-build",
  "fastrand",
@@ -149,6 +153,17 @@ version = "0.0.0"
 dependencies = [
  "dcsctp",
  "libfuzzer-sys",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ itertools = "0.14"
 libfuzzer-sys = "0.4"
 log = "0.4"
 thiserror = "2.0"
+arbitrary = { version = "1.3", features = ["derive"] }
 
 [workspace.lints.rust]
 dead-code = "allow"
@@ -52,6 +53,7 @@ cxx = { workspace = true, optional = true }
 fastrand = { workspace = true }
 log = { workspace = true }
 thiserror = { workspace = true }
+arbitrary = { workspace = true, optional = true }
 
 [build-dependencies]
 cxx-build = { workspace = true, optional = true }
@@ -64,7 +66,7 @@ workspace = true
 
 [features]
 cxx = ["dep:cxx", "dep:cxx-build"]
-fuzz-internals = []
+fuzz-internals = ["dep:arbitrary"]
 
 [lib]
 crate-type = ["lib", "staticlib"]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -32,3 +32,10 @@ path = "fuzz_targets/parse_packet.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "fuzz_outstanding_data"
+path = "fuzz_targets/fuzz_outstanding_data.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/fuzz_outstanding_data.rs
+++ b/fuzz/fuzz_targets/fuzz_outstanding_data.rs
@@ -1,0 +1,22 @@
+// Copyright 2026 The dcSCTP Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    #[allow(clippy::let_unit_value)]
+    let _ = dcsctp::fuzzer::fuzz_outstanding_data::fuzz_outstanding_data(data);
+});

--- a/src/fuzzer/fuzz_outstanding_data.rs
+++ b/src/fuzzer/fuzz_outstanding_data.rs
@@ -1,0 +1,142 @@
+// Copyright 2026 The dcSCTP Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::api::LifecycleId;
+use crate::api::SocketTime;
+use crate::api::StreamId;
+use crate::packet::data::Data;
+use crate::packet::sack_chunk::GapAckBlock;
+use crate::tx::outstanding_data::OutstandingData;
+use crate::types::Mid;
+use crate::types::OutgoingMessageId;
+use crate::types::Ssn;
+use crate::types::StreamKey;
+use crate::types::Tsn;
+use arbitrary::Arbitrary;
+use arbitrary::Unstructured;
+use std::time::Duration;
+
+#[derive(Arbitrary, Debug)]
+enum Command {
+    AdvanceTime {
+        delta_ms: u16,
+    },
+    Insert {
+        max_retransmissions: u16,
+        lifetime_ms: u32,
+        lifecycle_id: Option<u64>,
+        stream_id: u16,
+        ssn: u16,
+        mid: u32,
+        is_unordered: bool,
+        payload_len: u16,
+    },
+    HandleSack {
+        cumulative_tsn_ack: u32,
+        gap_ack_blocks: Vec<(u16, u16)>,
+        is_in_fast_recovery: bool,
+    },
+    ExpireOutstandingChunks,
+    NackAll,
+    GetChunksToBeFastRetransmitted {
+        max_size: usize,
+    },
+    GetChunksToBeRetransmitted {
+        max_size: usize,
+    },
+}
+
+pub fn fuzz_outstanding_data(data: &[u8]) {
+    let mut unstructured = Unstructured::new(data);
+    let commands = match unstructured.arbitrary::<Vec<Command>>() {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+
+    let data_chunk_header_size = 16;
+    let last_tsn = match u32::arbitrary(&mut unstructured) {
+        Ok(tsn) => Tsn(tsn),
+        Err(_) => return,
+    };
+    let mut outstanding_data = OutstandingData::new(data_chunk_header_size, last_tsn);
+    let mut next_message_id: u32 = 42;
+    let mut current_time = SocketTime::zero();
+
+    for command in commands {
+        match command {
+            Command::AdvanceTime { delta_ms } => {
+                current_time = current_time + Duration::from_millis(delta_ms as u64);
+            }
+            Command::Insert {
+                max_retransmissions,
+                lifetime_ms,
+                lifecycle_id,
+                stream_id,
+                ssn,
+                mid,
+                is_unordered,
+                payload_len,
+            } => {
+                // get_unsent_messages_to_discard must be called prior to calling insert, as
+                // documented.
+                outstanding_data.get_unsent_messages_to_discard();
+
+                let message_id = OutgoingMessageId(next_message_id);
+                next_message_id += 1;
+
+                let data = Data {
+                    stream_key: StreamKey::new(is_unordered, StreamId(stream_id)),
+                    ssn: Ssn(ssn),
+                    mid: Mid(mid),
+                    is_beginning: true,
+                    is_end: true,
+                    payload: vec![0; (payload_len % 1500) as usize + 1],
+                    ..Default::default()
+                };
+
+                let expires_at = current_time + Duration::from_millis(lifetime_ms as u64);
+
+                outstanding_data.insert(
+                    message_id,
+                    &data,
+                    current_time,
+                    max_retransmissions,
+                    expires_at,
+                    lifecycle_id.and_then(LifecycleId::new),
+                );
+            }
+            Command::HandleSack { cumulative_tsn_ack, gap_ack_blocks, is_in_fast_recovery } => {
+                let gap_blocks: Vec<GapAckBlock> =
+                    gap_ack_blocks.into_iter().map(|(s, e)| GapAckBlock::new(s, e)).collect();
+                outstanding_data.handle_sack(
+                    Tsn(cumulative_tsn_ack),
+                    &gap_blocks,
+                    is_in_fast_recovery,
+                );
+            }
+            Command::ExpireOutstandingChunks => {
+                outstanding_data.expire_outstanding_chunks(current_time);
+            }
+            Command::NackAll => {
+                outstanding_data.nack_all();
+            }
+            Command::GetChunksToBeFastRetransmitted { max_size } => {
+                outstanding_data.get_chunks_to_be_fast_retransmitted(current_time, max_size);
+            }
+            Command::GetChunksToBeRetransmitted { max_size } => {
+                outstanding_data.get_chunks_to_be_retransmitted(current_time, max_size);
+            }
+        }
+    }
+}

--- a/src/fuzzer/mod.rs
+++ b/src/fuzzer/mod.rs
@@ -17,6 +17,8 @@ use crate::packet::error_causes::error_cause_from_bytes;
 use crate::packet::parameter::parameters_from_bytes;
 use crate::packet::sctp_packet::SctpPacket;
 
+pub mod fuzz_outstanding_data;
+
 pub fn parse_parameters(data: &[u8]) {
     let _ = parameters_from_bytes(data);
 }


### PR DESCRIPTION
These two commits:

1. Adds a new fuzzer to OutstandingData - there have been a few bugs that had the potential of crashing (panic), and the fuzzer has been very good at finding these bugs. Uses "arbitrary" to generate input.
2. Reconfigures the fuzzers that run for every commit. Now they run for 20 seconds each, timeout after 1 second - to find stuck fuzzers - and run in parallel to shorten the time.