### PR TITLE
Flush send queue upon receiving COOKIE-ACK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## Unreleased
 
+### Fixed
+
+ - Explicitly flush buffered packets in the send queue upon receiving a COOKIE-ACK chunk.
+
 ## 0.1.12 - 2026-04-13
 
 ### Fixed

--- a/src/socket/connect.rs
+++ b/src/socket/connect.rs
@@ -420,6 +420,7 @@ pub(crate) fn handle_cookie_ack(state: &mut State, ctx: &mut Context, now: Socke
     ctx.heartbeat_interval.start(now);
     info!("Socket is connected!");
     ctx.events.borrow_mut().add(SocketEvent::OnConnected());
+    ctx.send_buffered_packets(state, now);
 }
 
 /// Handles the T1-init timer.

--- a/src/socket/socket_tests.rs
+++ b/src/socket/socket_tests.rs
@@ -578,6 +578,61 @@ mod tests {
     }
 
     #[test]
+    fn flushes_send_queue_immediately_upon_receiving_cookie_ack() {
+        let options = default_options();
+        let mut socket_a = Socket::new("A", &options);
+        let mut socket_z = Socket::new("Z", &options);
+
+        let payload_size = options.mtu + 100;
+        socket_a
+            .send(
+                Message::new(StreamId(1), PpId(53), vec![0; payload_size]),
+                &SendOptions::default(),
+            )
+            .unwrap();
+        socket_a.connect();
+
+        // A -> INIT -> Z
+        socket_z.handle_input(&expect_sent_packet!(socket_a.poll_event()));
+        // A <- INIT_ACK <- Z
+        socket_a.handle_input(&expect_sent_packet!(socket_z.poll_event()));
+
+        // A -> COOKIE_ECHO -> Z (bundled with the first DATA chunk)
+        let packet = expect_sent_packet!(socket_a.poll_event());
+        let parsed_packet = SctpPacket::from_bytes(&packet, &options).unwrap();
+        assert!(matches!(parsed_packet.chunks[0], Chunk::CookieEcho(_)));
+        assert!(matches!(parsed_packet.chunks[1], Chunk::Data(_)));
+
+        // Verify that socket_a does not produce any further SendPacket events right away
+        // (respecting the 1-packet limit while in COOKIE-ECHOED state).
+        expect_no_event!(socket_a.poll_event());
+
+        // Z -> COOKIE_ACK -> A
+        socket_z.handle_input(&packet);
+        expect_on_connected!(socket_z.poll_event());
+        let cookie_ack_packet = expect_sent_packet!(socket_z.poll_event());
+
+        // Inject the COOKIE_ACK into socket_a
+        socket_a.handle_input(&cookie_ack_packet);
+        expect_on_connected!(socket_a.poll_event());
+
+        // Receiving the COOKIE_ACK should allow more data to be sent.
+        let packet = expect_sent_packet!(socket_a.poll_event());
+        let parsed_packet = SctpPacket::from_bytes(&packet, &options).unwrap();
+        assert!(matches!(parsed_packet.chunks[0], Chunk::Data(_)));
+
+        // Inject the remaining data chunk to Z
+        socket_z.handle_input(&packet);
+
+        exchange_packets(&mut socket_a, &mut socket_z);
+
+        let message = socket_z.get_next_message().unwrap();
+        assert_eq!(message.stream_id, StreamId(1));
+        assert_eq!(message.payload.len(), payload_size);
+        assert!(socket_z.get_next_message().is_none());
+    }
+
+    #[test]
     fn shutdown_connection() {
         let mut socket_a = Socket::new("A", &default_options());
         let mut socket_z = Socket::new("Z", &default_options());


### PR DESCRIPTION
Previously, any data queued during the connection handshake that did not  fit into the initial COOKIE-ECHO packet was delayed. The socket did not  explicitly flush the send queue when transitioning to the Established  state, causing delays equivalent to the peer's delayed ACK timeout.

This change ensures that send_buffered_packets is called as soon as  the COOKIE-ACK is processed.