### PR TITLE
Prepare release for 0.1.13

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,10 @@ kernel.
 - **Test**: `cargo test` (Runs extensive unit and integration tests).
 - **Lint**: `cargo clippy --all-features --all-targets -- -D warnings`
 - **Format**: `cargo +nightly fmt --all -- --check`
+- **Release**: Bump the minor version in `Cargo.toml`, run `cargo build` to
+  update `Cargo.lock`, and move "Unreleased" items in `CHANGELOG.md` to the
+  new version. Create a commit with these changes using a previous release
+  (e.g., "v0.1.12") as a template.
 
 ## Contribution Rules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## Unreleased
 
+## 0.1.13 - 2026-05-20
+
 ### Fixed
 
  - Explicitly flush buffered packets in the send queue upon receiving a COOKIE-ACK chunk.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "dcsctp"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "arbitrary",
  "cxx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "fuzz"]
 
 [workspace.package]
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/webrtc/dcsctp"


### PR DESCRIPTION
I have also added an agent instruction on how to do this, so that you can just prompt your agent to create a new release next time (and well, I used it for this release).