### PR TITLE
Implement Verification Tag validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to
 
  - Account payload size of the deferred forward TSN messages.
 
+### Added
+
+ - Added Verification Tag validation on incoming packets as per RFC 9260 Section 8.5.
+
 ## 0.1.13 - 2026-05-20
 
 ### Fixed

--- a/src/packet/abort_chunk.rs
+++ b/src/packet/abort_chunk.rs
@@ -40,6 +40,7 @@ pub(crate) const CHUNK_TYPE: u8 = 6;
 /// ```
 #[derive(Debug, Default)]
 pub struct AbortChunk {
+    pub tag_reflected: bool,
     pub error_causes: Vec<ErrorCause>,
 }
 
@@ -50,13 +51,15 @@ impl TryFrom<RawChunk<'_>> for AbortChunk {
         ensure!(raw.typ == CHUNK_TYPE, ChunkParseError::InvalidType);
 
         let error_causes = error_cause_from_bytes(raw.value)?;
-        Ok(Self { error_causes })
+        let tag_reflected = (raw.flags & 0x01) != 0;
+        Ok(Self { tag_reflected, error_causes })
     }
 }
 
 impl SerializableTlv for AbortChunk {
     fn serialize_to(&self, output: &mut [u8]) {
-        let value = write_chunk_header(CHUNK_TYPE, 0, self.value_size(), output);
+        let flags = if self.tag_reflected { 1 } else { 0 };
+        let value = write_chunk_header(CHUNK_TYPE, flags, self.value_size(), output);
         parameters_serialize_to(&self.error_causes, value);
     }
 
@@ -67,7 +70,7 @@ impl SerializableTlv for AbortChunk {
 
 impl fmt::Display for AbortChunk {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "ABORT")
+        write!(f, "ABORT, tag_reflected={}", self.tag_reflected)
     }
 }
 
@@ -97,6 +100,7 @@ mod tests {
     #[test]
     fn serialize_and_deserialize() {
         let chunk = AbortChunk {
+            tag_reflected: true,
             error_causes: vec![ErrorCause::ProtocolViolation(ProtocolViolationErrorCause {
                 information: "Invalid foo".into(),
             })],
@@ -104,6 +108,8 @@ mod tests {
 
         let mut serialized = vec![0; chunk.serialized_size()];
         chunk.serialize_to(&mut serialized);
-        AbortChunk::try_from(RawChunk::from_bytes(&serialized).unwrap().0).unwrap();
+        let deserialized =
+            AbortChunk::try_from(RawChunk::from_bytes(&serialized).unwrap().0).unwrap();
+        assert!(deserialized.tag_reflected);
     }
 }

--- a/src/packet/error_causes.rs
+++ b/src/packet/error_causes.rs
@@ -17,6 +17,8 @@ use crate::packet::ChunkParseError;
 use crate::packet::SerializableTlv;
 use crate::packet::cookie_received_while_shutting_down::CookieReceivedWhileShuttingDownErrorCause;
 use crate::packet::cookie_received_while_shutting_down::{self};
+use crate::packet::missing_mandatory_parameter_error_cause::MissingMandatoryParameterErrorCause;
+use crate::packet::missing_mandatory_parameter_error_cause::{self};
 use crate::packet::no_user_data_error_cause::NoUserDataErrorCause;
 use crate::packet::no_user_data_error_cause::{self};
 use crate::packet::parameter::RawParameter;
@@ -36,6 +38,7 @@ pub enum ErrorCause {
     CookieReceivedWhileShuttingDown(CookieReceivedWhileShuttingDownErrorCause),
     UserInitiatedAbort(UserInitiatedAbortErrorCause),
     ProtocolViolation(ProtocolViolationErrorCause),
+    MissingMandatoryParameter(MissingMandatoryParameterErrorCause),
     Unknown(UnknownParameter),
 }
 
@@ -47,6 +50,7 @@ impl fmt::Display for ErrorCause {
             ErrorCause::CookieReceivedWhileShuttingDown(c) => c,
             ErrorCause::UserInitiatedAbort(c) => c,
             ErrorCause::ProtocolViolation(c) => c,
+            ErrorCause::MissingMandatoryParameter(c) => c,
             ErrorCause::Unknown(c) => c,
         };
         fmt::Display::fmt(c, f)
@@ -74,6 +78,10 @@ impl TryFrom<RawParameter<'_>> for ErrorCause {
             protocol_violation_error_cause::CAUSE_CODE => {
                 ProtocolViolationErrorCause::try_from(raw).map(ErrorCause::ProtocolViolation)
             }
+            missing_mandatory_parameter_error_cause::CAUSE_CODE => {
+                MissingMandatoryParameterErrorCause::try_from(raw)
+                    .map(ErrorCause::MissingMandatoryParameter)
+            }
             _ => UnknownParameter::try_from(raw).map(ErrorCause::Unknown),
         }
     }
@@ -87,6 +95,7 @@ impl AsSerializableTlv for ErrorCause {
             ErrorCause::CookieReceivedWhileShuttingDown(c) => c,
             ErrorCause::UserInitiatedAbort(c) => c,
             ErrorCause::ProtocolViolation(c) => c,
+            ErrorCause::MissingMandatoryParameter(c) => c,
             ErrorCause::Unknown(c) => c,
         }
     }

--- a/src/packet/missing_mandatory_parameter_error_cause.rs
+++ b/src/packet/missing_mandatory_parameter_error_cause.rs
@@ -1,0 +1,107 @@
+// Copyright 2026 The dcSCTP Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::packet::ChunkParseError;
+use crate::packet::SerializableTlv;
+use crate::packet::ensure;
+use crate::packet::parameter::RawParameter;
+use crate::packet::parameter::write_parameter_header;
+use crate::packet::read_u16_be;
+use crate::packet::read_u32_be;
+use crate::packet::write_u16_be;
+use crate::packet::write_u32_be;
+use std::fmt;
+
+pub(crate) const CAUSE_CODE: u16 = 2;
+
+/// Missing Mandatory Parameter error cause
+///
+/// See <https://datatracker.ietf.org/doc/html/rfc9260#section-3.3.10.2>.
+///
+/// ```txt
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// |     Cause Code=2              |      Cause Length=8+N*2       |
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// |                   Number of missing params=N                  |
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// |   Missing Param Type #1       |   Missing Param Type #2       |
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// |   Missing Param Type #N-1     |   Missing Param Type #N       |
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MissingMandatoryParameterErrorCause {
+    pub(crate) missing_parameters: Vec<u16>,
+}
+
+impl MissingMandatoryParameterErrorCause {
+    pub(crate) fn new(missing_parameters: Vec<u16>) -> Self {
+        Self { missing_parameters }
+    }
+}
+
+impl TryFrom<RawParameter<'_>> for MissingMandatoryParameterErrorCause {
+    type Error = ChunkParseError;
+
+    fn try_from(raw: RawParameter<'_>) -> Result<Self, ChunkParseError> {
+        ensure!(raw.typ == CAUSE_CODE, ChunkParseError::InvalidType);
+        ensure!(raw.value.len() >= 4, ChunkParseError::InvalidLength);
+
+        let num_params = read_u32_be!(&raw.value[0..4]) as usize;
+        ensure!(raw.value.len() == 4 + num_params * 2, ChunkParseError::InvalidLength);
+
+        let missing_parameters = raw.value[4..].chunks_exact(2).map(|c| read_u16_be!(c)).collect();
+        Ok(Self { missing_parameters })
+    }
+}
+
+impl SerializableTlv for MissingMandatoryParameterErrorCause {
+    fn serialize_to(&self, output: &mut [u8]) {
+        let value = write_parameter_header(CAUSE_CODE, self.value_size(), output);
+        write_u32_be!(&mut value[0..4], self.missing_parameters.len() as u32);
+        let chunks = value[4..].chunks_exact_mut(2);
+        for (&param_type, chunk) in self.missing_parameters.iter().zip(chunks) {
+            write_u16_be!(chunk, param_type);
+        }
+    }
+
+    fn value_size(&self) -> usize {
+        4 + self.missing_parameters.len() * 2
+    }
+}
+
+impl fmt::Display for MissingMandatoryParameterErrorCause {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Missing Mandatory Parameter, missing_parameters={:?}", self.missing_parameters)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serialize_and_deserialize() {
+        let cause = MissingMandatoryParameterErrorCause { missing_parameters: vec![7, 13] };
+
+        let mut serialized = vec![0; cause.serialized_size()];
+        cause.serialize_to(&mut serialized);
+
+        let error = MissingMandatoryParameterErrorCause::try_from(
+            RawParameter::from_bytes(&serialized).unwrap().0,
+        )
+        .unwrap();
+        assert_eq!(error.missing_parameters, vec![7, 13]);
+    }
+}

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -35,6 +35,7 @@ pub(crate) mod iforward_tsn_chunk;
 pub(crate) mod incoming_ssn_reset_request_parameter;
 pub(crate) mod init_ack_chunk;
 pub(crate) mod init_chunk;
+pub(crate) mod missing_mandatory_parameter_error_cause;
 pub(crate) mod no_user_data_error_cause;
 pub(crate) mod outgoing_ssn_reset_request_parameter;
 pub(crate) mod parameter;

--- a/src/packet/sctp_packet.rs
+++ b/src/packet/sctp_packet.rs
@@ -507,6 +507,7 @@ mod tests {
             options.mtu,
         )
         .add(&Chunk::Abort(AbortChunk {
+            tag_reflected: false,
             error_causes: vec![ErrorCause::UserInitiatedAbort(UserInitiatedAbortErrorCause {
                 reason: "".to_string(),
             })],

--- a/src/socket/connect.rs
+++ b/src/socket/connect.rs
@@ -32,12 +32,13 @@ use crate::packet::idata_chunk;
 use crate::packet::iforward_tsn_chunk;
 use crate::packet::init_ack_chunk::InitAckChunk;
 use crate::packet::init_chunk::InitChunk;
+use crate::packet::missing_mandatory_parameter_error_cause::MissingMandatoryParameterErrorCause;
 use crate::packet::parameter::Parameter;
-use crate::packet::protocol_violation_error_cause::ProtocolViolationErrorCause;
 use crate::packet::re_config_chunk;
 use crate::packet::sctp_packet::CommonHeader;
 use crate::packet::sctp_packet::SctpPacketBuilder;
 use crate::packet::shutdown_ack_chunk::ShutdownAckChunk;
+use crate::packet::state_cookie_parameter;
 use crate::packet::state_cookie_parameter::StateCookieParameter;
 use crate::packet::supported_extensions_parameter::SupportedExtensionsParameter;
 use crate::packet::zero_checksum_acceptable_parameter::ZeroChecksumAcceptableParameter;
@@ -257,15 +258,18 @@ pub(crate) fn handle_init_ack(
     }) else {
         ctx.events.borrow_mut().add(SocketEvent::SendPacket(
             SctpPacketBuilder::new(
-                s.verification_tag,
+                chunk.initiate_tag,
                 ctx.options.local_port,
                 ctx.options.remote_port,
                 round_down_to_4!(ctx.options.mtu),
             )
             .add(&Chunk::Abort(AbortChunk {
-                error_causes: vec![ErrorCause::ProtocolViolation(ProtocolViolationErrorCause {
-                    information: "INIT-ACK malformed".into(),
-                })],
+                tag_reflected: false,
+                error_causes: vec![ErrorCause::MissingMandatoryParameter(
+                    MissingMandatoryParameterErrorCause::new(vec![
+                        state_cookie_parameter::PARAMETER_TYPE,
+                    ]),
+                )],
             }))
             .build(),
         ));

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -262,7 +262,116 @@ impl Socket {
     }
 
     pub fn verification_tag(&self) -> u32 {
-        self.state.tcb().map_or(0, |tcb| tcb.my_verification_tag)
+        match &self.state {
+            State::Closed => 0,
+            State::CookieWait(s) => s.verification_tag,
+            State::CookieEchoed(s) => s.verification_tag,
+            State::Established(tcb)
+            | State::ShutdownPending(tcb)
+            | State::ShutdownSent(ShutdownState { tcb, .. })
+            | State::ShutdownReceived(tcb)
+            | State::ShutdownAckSent(ShutdownState { tcb, .. }) => tcb.my_verification_tag,
+        }
+    }
+
+    fn validate_packet(&self, packet: &SctpPacket) -> bool {
+        let header = &packet.common_header;
+        let my_verification_tag = self.verification_tag();
+
+        if !packet.chunks.is_empty() {
+            // ABORT (RFC 9260, Section 8.5.1, exception B).
+            if let Some(Chunk::Abort(abort)) =
+                packet.chunks.iter().find(|c| matches!(c, Chunk::Abort(_)))
+            {
+                // If the T-bit is set, the tag must match the peer's tag, which requires an active
+                // TCB.
+                let expected_tag = if abort.tag_reflected {
+                    self.state.tcb().map(|tcb| tcb.peer_verification_tag)
+                } else {
+                    Some(my_verification_tag)
+                };
+                if Some(header.verification_tag) == expected_tag {
+                    return true;
+                }
+                self.ctx.events.borrow_mut().add(SocketEvent::OnError(
+                    ErrorKind::ParseFailed,
+                    "ABORT chunk verification tag was wrong".into(),
+                ));
+                return false;
+            }
+
+            // SHUTDOWN COMPLETE (RFC 9260, Section 8.5.1, exception C).
+            if let Some(Chunk::ShutdownComplete(complete)) =
+                packet.chunks.iter().find(|c| matches!(c, Chunk::ShutdownComplete(_)))
+            {
+                // See above for explanation for this pattern.
+                let expected_tag = if complete.tag_reflected {
+                    self.state.tcb().map(|tcb| tcb.peer_verification_tag)
+                } else {
+                    Some(my_verification_tag)
+                };
+                if Some(header.verification_tag) == expected_tag {
+                    return true;
+                }
+                self.ctx.events.borrow_mut().add(SocketEvent::OnError(
+                    ErrorKind::ParseFailed,
+                    "SHUTDOWN_COMPLETE chunk verification tag was wrong".into(),
+                ));
+                return false;
+            }
+
+            // SHUTDOWN ACK (RFC 9260, Section 8.5.1, exception E).
+            if packet.chunks.iter().any(|c| matches!(c, Chunk::ShutdownAck(_))) {
+                if matches!(
+                    self.state,
+                    State::Closed | State::CookieWait(_) | State::CookieEchoed(_)
+                ) {
+                    return true;
+                }
+                if header.verification_tag == my_verification_tag {
+                    return true;
+                }
+                self.ctx.events.borrow_mut().add(SocketEvent::OnError(
+                    ErrorKind::ParseFailed,
+                    "SHUTDOWN_ACK chunk verification tag was wrong".into(),
+                ));
+                return false;
+            }
+
+            // COOKIE ECHO Exception (RFC 9260, Section 8.5.1, Exception D):
+            // If the packet contains a COOKIE ECHO, it is guaranteed to be the first chunk.
+            // Bypass standard verification tag checks to the chunk handler.
+            if let Some(Chunk::CookieEcho(_)) = packet.chunks.first() {
+                return true;
+            }
+        }
+
+        // INIT (RFC 9260, Section 8.5.1, exception A).
+        if header.verification_tag == 0 {
+            if packet.chunks.len() == 1 && matches!(packet.chunks[0], Chunk::Init(_)) {
+                return true;
+            }
+            self.ctx.events.borrow_mut().add(SocketEvent::OnError(
+                ErrorKind::ParseFailed,
+                "Only a single INIT chunk can be present in packets sent on verification_tag = 0"
+                    .into(),
+            ));
+            return false;
+        }
+
+        // Standard tag validation rule
+        if header.verification_tag == my_verification_tag {
+            return true;
+        }
+
+        self.ctx.events.borrow_mut().add(SocketEvent::OnError(
+            ErrorKind::ParseFailed,
+            format!(
+                "Packet has invalid verification tag: {:08x}, expected {:08x}",
+                header.verification_tag, my_verification_tag
+            ),
+        ));
+        false
     }
 
     fn handle_unrecognized_chunk(&mut self, chunk: UnknownChunk) -> bool {
@@ -332,6 +441,9 @@ impl DcSctpSocket for Socket {
                 ));
             }
             Ok(packet) => {
+                if !self.validate_packet(&packet) {
+                    return;
+                }
                 maybe_send_shutdown_on_packet_received(
                     &mut self.state,
                     &mut self.ctx,
@@ -457,6 +569,7 @@ impl DcSctpSocket for Socket {
                 self.ctx.events.borrow_mut().add(SocketEvent::SendPacket(
                     tcb.new_packet()
                         .add(&Chunk::Abort(AbortChunk {
+                            tag_reflected: false,
                             error_causes: vec![ErrorCause::UserInitiatedAbort(
                                 UserInitiatedAbortErrorCause {
                                     reason: "Too many retransmissions".into(),
@@ -527,6 +640,7 @@ impl DcSctpSocket for Socket {
                 self.ctx.events.borrow_mut().add(SocketEvent::SendPacket(
                     tcb.new_packet()
                         .add(&Chunk::Abort(AbortChunk {
+                            tag_reflected: false,
                             error_causes: vec![ErrorCause::UserInitiatedAbort(
                                 UserInitiatedAbortErrorCause { reason: "Close called".into() },
                             )],

--- a/src/socket/shutdown.rs
+++ b/src/socket/shutdown.rs
@@ -229,6 +229,7 @@ pub(crate) fn handle_t2_shutdown_timeout(
     ctx.events.borrow_mut().add(SocketEvent::SendPacket(
         tcb.new_packet()
             .add(&Chunk::Abort(AbortChunk {
+                tag_reflected: false,
                 error_causes: vec![ErrorCause::UserInitiatedAbort(UserInitiatedAbortErrorCause {
                     reason: "Too many retransmissions".into(),
                 })],

--- a/src/socket/socket_tests.rs
+++ b/src/socket/socket_tests.rs
@@ -30,6 +30,7 @@ mod tests {
     use crate::api::ZERO_CHECKSUM_ALTERNATE_ERROR_DETECTION_METHOD_LOWER_LAYER_DTLS;
     use crate::api::ZERO_CHECKSUM_ALTERNATE_ERROR_DETECTION_METHOD_NONE;
     use crate::math::round_down_to_4;
+    use crate::packet::abort_chunk::AbortChunk;
     use crate::packet::chunk::Chunk;
     use crate::packet::data::Data;
     use crate::packet::data_chunk;
@@ -44,6 +45,8 @@ mod tests {
     use crate::packet::sctp_packet;
     use crate::packet::sctp_packet::SctpPacket;
     use crate::packet::sctp_packet::SctpPacketBuilder;
+    use crate::packet::shutdown_ack_chunk::ShutdownAckChunk;
+    use crate::packet::shutdown_complete_chunk::ShutdownCompleteChunk;
     use crate::packet::unknown_chunk::UnknownChunk;
     use crate::packet::unrecognized_chunk_error_cause::UnrecognizedChunkErrorCause;
     use crate::rx::reassembly_queue::HIGH_WATERMARK_LIMIT;
@@ -92,6 +95,10 @@ mod tests {
             heartbeat_interval: Duration::ZERO,
             ..Options::default()
         }
+    }
+
+    fn generate_invalid_tag(tag: u32) -> u32 {
+        if tag == 1 { 2 } else { tag ^ 1 }
     }
 
     fn exchange_packets(
@@ -338,12 +345,21 @@ mod tests {
         .build();
         socket_a.handle_input(&packet);
 
-        assert!(matches!(
-            SctpPacket::from_bytes(&expect_sent_packet!(socket_a.poll_event()), &options)
-                .unwrap()
-                .chunks[0],
-            Chunk::Abort(_)
-        ));
+        let abort_packet =
+            SctpPacket::from_bytes(&expect_sent_packet!(socket_a.poll_event()), &options).unwrap();
+        let Chunk::Abort(abort) = &abort_packet.chunks[0] else {
+            panic!("Expected Abort chunk");
+        };
+        assert_eq!(abort.error_causes.len(), 1);
+        match &abort.error_causes[0] {
+            ErrorCause::MissingMandatoryParameter(c) => {
+                assert_eq!(
+                    c.missing_parameters,
+                    vec![crate::packet::state_cookie_parameter::PARAMETER_TYPE]
+                );
+            }
+            _ => panic!("Expected MissingMandatoryParameter error cause"),
+        }
         assert_eq!(expect_on_aborted!(socket_a.poll_event()), ErrorKind::ProtocolViolation);
     }
 
@@ -3710,5 +3726,198 @@ mod tests {
         let packet = expect_sent_packet!(socket_z.poll_event());
         let packet = SctpPacket::from_bytes(&packet, &options).unwrap();
         assert!(packet.chunks.iter().any(|c| matches!(c, Chunk::Sack(_))));
+    }
+
+    #[test]
+    fn test_verify_vtag_with_closed_state() {
+        let options = default_options();
+        let mut socket_a = Socket::new("A", &options);
+
+        // Closed State Validation (only INIT with tag 0 accepted).
+        let packet =
+            SctpPacketBuilder::new(123, options.local_port, options.remote_port, options.mtu)
+                .add(&Chunk::HeartbeatRequest(HeartbeatRequestChunk { parameters: vec![] }))
+                .build();
+        socket_a.handle_input(&packet);
+        assert_eq!(expect_on_error!(socket_a.poll_event()), ErrorKind::ParseFailed);
+
+        let packet =
+            SctpPacketBuilder::new(0, options.local_port, options.remote_port, options.mtu)
+                .add(&Chunk::HeartbeatRequest(HeartbeatRequestChunk { parameters: vec![] }))
+                .build();
+        socket_a.handle_input(&packet);
+        assert_eq!(expect_on_error!(socket_a.poll_event()), ErrorKind::ParseFailed);
+    }
+
+    #[test]
+    fn test_verify_vtag_with_established_state() {
+        let options = default_options();
+        let mut socket_a = Socket::new("A", &options);
+        let mut socket_z = Socket::new("Z", &options);
+        connect_sockets(&mut socket_a, &mut socket_z);
+
+        let my_tag = socket_a.verification_tag();
+        // Correct tag:
+        let packet =
+            SctpPacketBuilder::new(my_tag, options.local_port, options.remote_port, options.mtu)
+                .add(&Chunk::HeartbeatRequest(HeartbeatRequestChunk { parameters: vec![] }))
+                .build();
+        socket_a.handle_input(&packet);
+        let response = expect_sent_packet!(socket_a.poll_event());
+        let parsed = SctpPacket::from_bytes(&response, &options).unwrap();
+        assert!(matches!(parsed.chunks[0], Chunk::HeartbeatAck(_)));
+
+        // Incorrect tag:
+        let packet = SctpPacketBuilder::new(
+            generate_invalid_tag(my_tag),
+            options.local_port,
+            options.remote_port,
+            options.mtu,
+        )
+        .add(&Chunk::HeartbeatRequest(HeartbeatRequestChunk { parameters: vec![] }))
+        .build();
+        socket_a.handle_input(&packet);
+        assert_eq!(expect_on_error!(socket_a.poll_event()), ErrorKind::ParseFailed);
+    }
+
+    #[test]
+    fn test_verify_vtag_with_abort_exceptions() {
+        let options = default_options();
+        let mut socket_a = Socket::new("A", &options);
+        let mut socket_z = Socket::new("Z", &options);
+        connect_sockets(&mut socket_a, &mut socket_z);
+
+        let my_tag = socket_a.verification_tag();
+        let peer_tag = socket_z.verification_tag();
+
+        // Correct ABORT with T-bit = 0: MUST match own (local) verification tag.
+        let packet =
+            SctpPacketBuilder::new(my_tag, options.local_port, options.remote_port, options.mtu)
+                .add(&Chunk::Abort(AbortChunk { tag_reflected: false, error_causes: vec![] }))
+                .build();
+        socket_a.handle_input(&packet);
+        assert_eq!(expect_on_aborted!(socket_a.poll_event()), ErrorKind::PeerReported);
+
+        // Incorrect ABORT with T-bit = 0.
+        let packet = SctpPacketBuilder::new(
+            generate_invalid_tag(peer_tag),
+            options.local_port,
+            options.remote_port,
+            options.mtu,
+        )
+        .add(&Chunk::Abort(AbortChunk { tag_reflected: false, error_causes: vec![] }))
+        .build();
+        socket_z.handle_input(&packet);
+        assert_eq!(expect_on_error!(socket_z.poll_event()), ErrorKind::ParseFailed);
+        assert_eq!(socket_z.state(), SocketState::Connected);
+
+        // Correct packet with T-bit = 1: MUST match peer's verification tag.
+        let packet =
+            SctpPacketBuilder::new(my_tag, options.local_port, options.remote_port, options.mtu)
+                .add(&Chunk::Abort(AbortChunk { tag_reflected: true, error_causes: vec![] }))
+                .build();
+        socket_z.handle_input(&packet);
+        assert_eq!(expect_on_aborted!(socket_z.poll_event()), ErrorKind::PeerReported);
+
+        // ABORT bundled as second chunk.
+        let mut socket_a2 = Socket::new("A2", &options);
+        let mut socket_z2 = Socket::new("Z2", &options);
+        connect_sockets(&mut socket_a2, &mut socket_z2);
+        let my_tag = socket_a2.verification_tag();
+
+        let packet =
+            SctpPacketBuilder::new(my_tag, options.local_port, options.remote_port, options.mtu)
+                .add(&Chunk::HeartbeatRequest(HeartbeatRequestChunk { parameters: vec![] }))
+                .add(&Chunk::Abort(AbortChunk { tag_reflected: false, error_causes: vec![] }))
+                .build();
+        socket_a2.handle_input(&packet);
+        assert!(matches!(socket_a2.poll_event(), Some(SocketEvent::SendPacket(_))));
+        assert_eq!(expect_on_aborted!(socket_a2.poll_event()), ErrorKind::PeerReported);
+
+        // ABORT with random tag and T-bit = 1 in CookieWait.
+        let mut socket_a3 = Socket::new("A3", &options);
+        socket_a3.connect(); // Transition to CookieWait
+        let _ = expect_sent_packet!(socket_a3.poll_event());
+
+        let packet =
+            SctpPacketBuilder::new(999, options.local_port, options.remote_port, options.mtu)
+                .add(&Chunk::Abort(AbortChunk { tag_reflected: true, error_causes: vec![] }))
+                .build();
+        socket_a3.handle_input(&packet);
+        assert_eq!(expect_on_error!(socket_a3.poll_event()), ErrorKind::ParseFailed);
+    }
+
+    #[test]
+    fn test_verify_vtag_with_shutdown_complete_exceptions() {
+        let options = default_options();
+        let mut socket_a = Socket::new("A", &options);
+        let mut socket_z = Socket::new("Z", &options);
+        connect_sockets(&mut socket_a, &mut socket_z);
+
+        let my_tag = socket_a.verification_tag();
+        // Correct SHUTDOWN COMPLETE with T-bit = 0: MUST match own (local) verification tag.
+        let packet =
+            SctpPacketBuilder::new(my_tag, options.local_port, options.remote_port, options.mtu)
+                .add(&Chunk::ShutdownComplete(ShutdownCompleteChunk { tag_reflected: false }))
+                .build();
+        socket_a.handle_input(&packet);
+        expect_no_event!(socket_a.poll_event());
+
+        // Incorrect SHUTDOWN COMPLETE with T-bit = 0.
+        let packet = SctpPacketBuilder::new(
+            generate_invalid_tag(my_tag),
+            options.local_port,
+            options.remote_port,
+            options.mtu,
+        )
+        .add(&Chunk::ShutdownComplete(ShutdownCompleteChunk { tag_reflected: false }))
+        .build();
+        socket_a.handle_input(&packet);
+        assert_eq!(expect_on_error!(socket_a.poll_event()), ErrorKind::ParseFailed);
+
+        // Correct SHUTDOWN COMPLETE with T-bit = 1: MUST match peer's verification tag.
+        let packet =
+            SctpPacketBuilder::new(my_tag, options.local_port, options.remote_port, options.mtu)
+                .add(&Chunk::ShutdownComplete(ShutdownCompleteChunk { tag_reflected: true }))
+                .build();
+        socket_z.handle_input(&packet);
+        expect_no_event!(socket_z.poll_event());
+
+        // Incorrect SHUTDOWN COMPLETE with T-bit = 1:
+        let packet = SctpPacketBuilder::new(
+            generate_invalid_tag(my_tag),
+            options.local_port,
+            options.remote_port,
+            options.mtu,
+        )
+        .add(&Chunk::ShutdownComplete(ShutdownCompleteChunk { tag_reflected: true }))
+        .build();
+        socket_z.handle_input(&packet);
+        assert_eq!(expect_on_error!(socket_z.poll_event()), ErrorKind::ParseFailed);
+    }
+
+    #[test]
+    fn test_verify_vtag_with_shutdown_ack_exceptions() {
+        let options = default_options();
+        let mut socket = Socket::new("A", &options);
+
+        // Transition to CookieWait
+        socket.connect();
+        let _ = expect_sent_packet!(socket.poll_event());
+
+        // Receive an out-of-the-blue SHUTDOWN ACK.
+        let packet =
+            SctpPacketBuilder::new(999, options.local_port, options.remote_port, options.mtu)
+                .add(&Chunk::ShutdownAck(ShutdownAckChunk {}))
+                .build();
+        socket.handle_input(&packet);
+
+        // Expect a SHUTDOWN COMPLETE.
+        let response = expect_sent_packet!(socket.poll_event());
+        let parsed = SctpPacket::from_bytes(&response, &options).unwrap();
+        assert!(matches!(parsed.chunks[0], Chunk::ShutdownComplete(_)));
+        if let Chunk::ShutdownComplete(ref complete) = parsed.chunks[0] {
+            assert!(complete.tag_reflected);
+        }
     }
 }


### PR DESCRIPTION
Previously, the packet parser parsed verification tags but did not  perform validation on them. With SCTP-over-DTLS, the risk of packet corruption or out-of-the-blue packets is mitigated, but when using dcSCTP outside WebRTC, this is more important.

This change implements Verification Tag validation as per RFC 9260  Section 8.5. It adds the tag_reflected flag to AbortChunk representing  the Terminate bit (T-bit), performs state-aware verification, handles  special rules for INIT, COOKIE ECHO, ABORT, and SHUTDOWN COMPLETE  chunks, and adds test cases.