### PR TITLE
Refactor ReassemblyQueue to separate byte tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ and this project adheres to
 
 ## Unreleased
 
+### Fixed
+
  - Account payload size of the deferred forward TSN messages.
+ - Refactored ReassemblyQueue byte tracking into smaller parts, fixing integer
+   underflows and double-counting bugs.
 
 ### Added
 

--- a/src/rx/interleaved_reassembly_streams.rs
+++ b/src/rx/interleaved_reassembly_streams.rs
@@ -130,17 +130,18 @@ impl UnorderedStream {
 pub struct InterleavedReassemblyStreams {
     ordered: HashMap<StreamId, OrderedStream>,
     unordered: HashMap<StreamId, UnorderedStream>,
+    queued_bytes: usize,
 }
 
 impl InterleavedReassemblyStreams {
     pub fn new() -> Self {
-        Self { ordered: HashMap::new(), unordered: HashMap::new() }
+        Self { ordered: HashMap::new(), unordered: HashMap::new(), queued_bytes: 0 }
     }
 }
 
 impl ReassemblyStreams for InterleavedReassemblyStreams {
-    fn add(&mut self, _tsn: Tsn, data: Data, on_reassembled: &mut dyn FnMut(Message)) -> isize {
-        match data.stream_key {
+    fn add(&mut self, _tsn: Tsn, data: Data, on_reassembled: &mut dyn FnMut(Message)) {
+        let diff = match data.stream_key {
             StreamKey::Ordered(stream_id) => self
                 .ordered
                 .entry(stream_id)
@@ -151,7 +152,8 @@ impl ReassemblyStreams for InterleavedReassemblyStreams {
                 .entry(stream_id)
                 .or_insert_with(|| UnorderedStream::new(stream_id))
                 .add(data, on_reassembled),
-        }
+        };
+        self.queued_bytes = self.queued_bytes.strict_add_signed(diff);
     }
 
     fn handle_forward_tsn(
@@ -159,8 +161,7 @@ impl ReassemblyStreams for InterleavedReassemblyStreams {
         _new_cumulative_ack: Tsn,
         skipped_streams: &[SkippedStream],
         on_reassembled: &mut dyn FnMut(Message),
-    ) -> usize {
-        let mut released_bytes = 0;
+    ) {
         for skipped_stream in skipped_streams {
             if let SkippedStream::IForwardTsn(stream_key, mid) = skipped_stream {
                 match stream_key {
@@ -170,7 +171,7 @@ impl ReassemblyStreams for InterleavedReassemblyStreams {
                             .entry(*stream_id)
                             .or_insert_with(|| OrderedStream::new(*stream_id, Mid(0)));
 
-                        released_bytes +=
+                        self.queued_bytes -=
                             stream.intervals.retain(|interval| interval.start.mid > *mid);
 
                         if stream.next_mid <= *mid {
@@ -178,7 +179,7 @@ impl ReassemblyStreams for InterleavedReassemblyStreams {
                         }
 
                         // Try to assemble messages after the jump
-                        released_bytes += stream.try_assemble_next(on_reassembled);
+                        self.queued_bytes -= stream.try_assemble_next(on_reassembled);
                     }
                     StreamKey::Unordered(stream_id) => {
                         let stream = self
@@ -186,28 +187,35 @@ impl ReassemblyStreams for InterleavedReassemblyStreams {
                             .entry(*stream_id)
                             .or_insert_with(|| UnorderedStream::new(*stream_id));
 
-                        released_bytes +=
+                        self.queued_bytes -=
                             stream.intervals.retain(|interval| interval.start.mid > *mid);
                     }
                 }
             }
         }
-        released_bytes
     }
 
     fn reset_streams(&mut self, streams: &[StreamId]) {
         if streams.is_empty() {
             for stream in self.ordered.values_mut() {
+                self.queued_bytes -= stream.intervals.total_bytes();
                 stream.next_mid = Mid(0);
+                stream.intervals = IntervalList::default();
             }
         } else {
             for stream_id in streams {
                 if let Some(stream) = self.ordered.get_mut(stream_id) {
+                    self.queued_bytes -= stream.intervals.total_bytes();
                     stream.next_mid = Mid(0);
+                    stream.intervals = IntervalList::default();
                 }
             }
         }
         // Unordered streams don't need reset as they don't block on MID.
+    }
+
+    fn queued_bytes(&self) -> usize {
+        self.queued_bytes
     }
 
     fn get_handover_readiness(&self) -> HandoverReadiness {
@@ -256,11 +264,15 @@ mod tests {
         let mut s = InterleavedReassemblyStreams::new();
         let mut seq = DataSequencer::new(StreamId(1));
 
-        assert_eq!(s.add(Tsn(1), seq.unordered("a", "B"), &mut |_| {}), 1);
-        assert_eq!(s.add(Tsn(2), seq.unordered("bcd", ""), &mut |_| {}), 3);
-        assert_eq!(s.add(Tsn(3), seq.unordered("ef", ""), &mut |_| {}), 2);
+        s.add(Tsn(1), seq.unordered("a", "B"), &mut |_| {});
+        assert_eq!(s.queued_bytes(), 1);
+        s.add(Tsn(2), seq.unordered("bcd", ""), &mut |_| {});
+        assert_eq!(s.queued_bytes(), 4);
+        s.add(Tsn(3), seq.unordered("ef", ""), &mut |_| {});
+        assert_eq!(s.queued_bytes(), 6);
         // Adding the end fragment should make it empty again.
-        assert_eq!(s.add(Tsn(4), seq.unordered("g", "E"), &mut |_| {}), -6);
+        s.add(Tsn(4), seq.unordered("g", "E"), &mut |_| {});
+        assert_eq!(s.queued_bytes(), 0);
     }
 
     #[test]
@@ -274,11 +286,15 @@ mod tests {
         let c3 = seq.unordered("ef", "");
         let c4 = seq.unordered("g", "E");
 
-        assert_eq!(s.add(Tsn(1), c1, &mut |m| messages.push(m)), 1);
-        assert_eq!(s.add(Tsn(2), c2, &mut |m| messages.push(m)), 3);
-        assert_eq!(s.add(Tsn(4), c4, &mut |m| messages.push(m)), 1);
+        s.add(Tsn(1), c1, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 1);
+        s.add(Tsn(2), c2, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 4);
+        s.add(Tsn(4), c4, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 5);
         assert!(messages.is_empty());
-        assert_eq!(s.add(Tsn(3), c3, &mut |m| messages.push(m)), -5);
+        s.add(Tsn(3), c3, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 0);
         assert_eq!(messages.len(), 1);
     }
 
@@ -293,10 +309,14 @@ mod tests {
         let c3 = seq.ordered("ef", "");
         let c4 = seq.ordered("g", "E");
 
-        assert_eq!(s.add(Tsn(1), c1, &mut |m| messages.push(m)), 1);
-        assert_eq!(s.add(Tsn(2), c2, &mut |m| messages.push(m)), 3);
-        assert_eq!(s.add(Tsn(3), c3, &mut |m| messages.push(m)), 2);
-        assert_eq!(s.add(Tsn(4), c4, &mut |m| messages.push(m)), -6);
+        s.add(Tsn(1), c1, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 1);
+        s.add(Tsn(2), c2, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 4);
+        s.add(Tsn(3), c3, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 6);
+        s.add(Tsn(4), c4, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 0);
         assert_eq!(messages.len(), 1);
     }
 
@@ -314,14 +334,21 @@ mod tests {
         let c31 = seq.ordered("ij", "B");
         let c32 = seq.ordered("k", "E");
 
-        assert_eq!(s.add(Tsn(1), c11, &mut |m| messages.push(m)), 1);
-        assert_eq!(s.add(Tsn(3), c13, &mut |m| messages.push(m)), 2);
-        assert_eq!(s.add(Tsn(4), c14, &mut |m| messages.push(m)), 1);
-        assert_eq!(s.add(Tsn(5), c21, &mut |m| messages.push(m)), 1);
-        assert_eq!(s.add(Tsn(6), c31, &mut |m| messages.push(m)), 2);
-        assert_eq!(s.add(Tsn(7), c32, &mut |m| messages.push(m)), 1);
+        s.add(Tsn(1), c11, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 1);
+        s.add(Tsn(3), c13, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 3);
+        s.add(Tsn(4), c14, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 4);
+        s.add(Tsn(5), c21, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 5);
+        s.add(Tsn(6), c31, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 7);
+        s.add(Tsn(7), c32, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 8);
         assert!(messages.is_empty());
-        assert_eq!(s.add(Tsn(2), c12, &mut |m| messages.push(m)), -8);
+        s.add(Tsn(2), c12, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 0);
 
         assert_eq!(messages.len(), 3);
     }
@@ -336,18 +363,19 @@ mod tests {
         let c2 = seq.unordered("bcd", "");
         let c3 = seq.unordered("ef", "");
 
-        assert_eq!(s.add(Tsn(1), c1, &mut |m| messages.push(m)), 1);
-        assert_eq!(s.add(Tsn(2), c2, &mut |m| messages.push(m)), 3);
-        assert_eq!(s.add(Tsn(3), c3, &mut |m| messages.push(m)), 2);
+        s.add(Tsn(1), c1, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 1);
+        s.add(Tsn(2), c2, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 4);
+        s.add(Tsn(3), c3, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 6);
         // Adding the end fragment should make it empty again.
-        assert_eq!(
-            s.handle_forward_tsn(
-                Tsn(3),
-                &[SkippedStream::IForwardTsn(StreamKey::Unordered(StreamId(1)), Mid(0))],
-                &mut |m| messages.push(m)
-            ),
-            6
+        s.handle_forward_tsn(
+            Tsn(3),
+            &[SkippedStream::IForwardTsn(StreamKey::Unordered(StreamId(1)), Mid(0))],
+            &mut |m| messages.push(m),
         );
+        assert_eq!(s.queued_bytes(), 0);
     }
 
     #[test]
@@ -359,18 +387,19 @@ mod tests {
         let c1 = seq.ordered("a", "B");
         let c2 = seq.ordered("bcd", "");
         let c3 = seq.ordered("ef", "");
-        assert_eq!(s.add(Tsn(1), c1, &mut |m| messages.push(m)), 1);
-        assert_eq!(s.add(Tsn(2), c2, &mut |m| messages.push(m)), 3);
-        assert_eq!(s.add(Tsn(3), c3, &mut |m| messages.push(m)), 2);
+        s.add(Tsn(1), c1, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 1);
+        s.add(Tsn(2), c2, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 4);
+        s.add(Tsn(3), c3, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 6);
         // Adding the end fragment should make it empty again.
-        assert_eq!(
-            s.handle_forward_tsn(
-                Tsn(3),
-                &[SkippedStream::IForwardTsn(StreamKey::Ordered(StreamId(1)), Mid(0))],
-                &mut |m| messages.push(m)
-            ),
-            6
+        s.handle_forward_tsn(
+            Tsn(3),
+            &[SkippedStream::IForwardTsn(StreamKey::Ordered(StreamId(1)), Mid(0))],
+            &mut |m| messages.push(m),
         );
+        assert_eq!(s.queued_bytes(), 0);
     }
 
     #[test]
@@ -387,21 +416,25 @@ mod tests {
         let c6 = seq.ordered("ij", "B");
         let c7 = seq.ordered("k", "E");
 
-        assert_eq!(s.add(Tsn(1), c1, &mut |m| messages.push(m)), 1);
-        assert_eq!(s.add(Tsn(3), c3, &mut |m| messages.push(m)), 2);
-        assert_eq!(s.add(Tsn(4), c4, &mut |m| messages.push(m)), 1);
-        assert_eq!(s.add(Tsn(5), c5, &mut |m| messages.push(m)), 1);
-        assert_eq!(s.add(Tsn(6), c6, &mut |m| messages.push(m)), 2);
-        assert_eq!(s.add(Tsn(7), c7, &mut |m| messages.push(m)), 1);
+        s.add(Tsn(1), c1, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 1);
+        s.add(Tsn(3), c3, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 3);
+        s.add(Tsn(4), c4, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 4);
+        s.add(Tsn(5), c5, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 5);
+        s.add(Tsn(6), c6, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 7);
+        s.add(Tsn(7), c7, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 8);
 
-        assert_eq!(
-            s.handle_forward_tsn(
-                Tsn(8),
-                &[SkippedStream::IForwardTsn(StreamKey::Ordered(StreamId(1)), Mid(2))],
-                &mut |m| messages.push(m)
-            ),
-            8
+        s.handle_forward_tsn(
+            Tsn(8),
+            &[SkippedStream::IForwardTsn(StreamKey::Ordered(StreamId(1)), Mid(2))],
+            &mut |m| messages.push(m),
         );
+        assert_eq!(s.queued_bytes(), 0);
     }
 
     #[test]
@@ -418,23 +451,27 @@ mod tests {
         let c6 = seq.ordered("ij", "B");
         let c7 = seq.ordered("k", "E");
 
-        assert_eq!(s.add(Tsn(1), c1, &mut |m| messages.push(m)), 1);
+        s.add(Tsn(1), c1, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 1);
 
-        assert_eq!(s.add(Tsn(3), c3, &mut |m| messages.push(m)), 2);
-        assert_eq!(s.add(Tsn(4), c4, &mut |m| messages.push(m)), 1);
+        s.add(Tsn(3), c3, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 3);
+        s.add(Tsn(4), c4, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 4);
 
-        assert_eq!(s.add(Tsn(5), c5, &mut |m| messages.push(m)), 1);
-        assert_eq!(s.add(Tsn(6), c6, &mut |m| messages.push(m)), 2);
-        assert_eq!(s.add(Tsn(7), c7, &mut |m| messages.push(m)), 1);
+        s.add(Tsn(5), c5, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 5);
+        s.add(Tsn(6), c6, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 7);
+        s.add(Tsn(7), c7, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 8);
 
-        assert_eq!(
-            s.handle_forward_tsn(
-                Tsn(8),
-                &[SkippedStream::IForwardTsn(StreamKey::Ordered(StreamId(1)), Mid(0))],
-                &mut |m| messages.push(m)
-            ),
-            8
+        s.handle_forward_tsn(
+            Tsn(8),
+            &[SkippedStream::IForwardTsn(StreamKey::Ordered(StreamId(1)), Mid(0))],
+            &mut |m| messages.push(m),
         );
+        assert_eq!(s.queued_bytes(), 0);
         assert_eq!(messages.len(), 2);
     }
 
@@ -446,16 +483,15 @@ mod tests {
 
         seq.ordered("abc", "BE"); // TSN=1 Not received.
         let c2 = seq.ordered("def", "BE");
-        assert_eq!(
-            s.handle_forward_tsn(
-                Tsn(1),
-                &[SkippedStream::IForwardTsn(StreamKey::Ordered(StreamId(1)), Mid(0))],
-                &mut |m| messages.push(m)
-            ),
-            0
+        s.handle_forward_tsn(
+            Tsn(1),
+            &[SkippedStream::IForwardTsn(StreamKey::Ordered(StreamId(1)), Mid(0))],
+            &mut |m| messages.push(m),
         );
+        assert_eq!(s.queued_bytes(), 0);
 
-        assert_eq!(s.add(Tsn(2), c2, &mut |m| messages.push(m)), 0);
+        s.add(Tsn(2), c2, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 0);
         assert_eq!(messages.len(), 1);
     }
 
@@ -470,16 +506,20 @@ mod tests {
         let data3 = seq.unordered("c", "BE");
         let data4 = seq.unordered("d", "BE");
 
-        assert_eq!(s.add(Tsn(1), data1, &mut |m| messages.push(m)), 0);
+        s.add(Tsn(1), data1, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 0);
         assert_eq!(messages.len(), 1);
 
-        assert_eq!(s.add(Tsn(3), data3, &mut |m| messages.push(m)), 0);
+        s.add(Tsn(3), data3, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 0);
         assert_eq!(messages.len(), 2);
 
-        assert_eq!(s.add(Tsn(2), data2, &mut |m| messages.push(m)), 0);
+        s.add(Tsn(2), data2, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 0);
         assert_eq!(messages.len(), 3);
 
-        assert_eq!(s.add(Tsn(4), data4, &mut |m| messages.push(m)), 0);
+        s.add(Tsn(4), data4, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 0);
         assert_eq!(messages.len(), 4);
     }
 
@@ -494,16 +534,20 @@ mod tests {
         let data3 = seq.ordered("c", "BE");
         let data4 = seq.ordered("d", "BE");
 
-        assert_eq!(s.add(Tsn(1), data1, &mut |m| messages.push(m)), 0);
+        s.add(Tsn(1), data1, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 0);
         assert_eq!(messages.len(), 1);
 
-        assert_eq!(s.add(Tsn(3), data3, &mut |m| messages.push(m)), 1);
+        s.add(Tsn(3), data3, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 1);
         assert_eq!(messages.len(), 1);
 
-        assert_eq!(s.add(Tsn(2), data2, &mut |m| messages.push(m)), -1);
+        s.add(Tsn(2), data2, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 0);
         assert_eq!(messages.len(), 3);
 
-        assert_eq!(s.add(Tsn(4), data4, &mut |m| messages.push(m)), 0);
+        s.add(Tsn(4), data4, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 0);
         assert_eq!(messages.len(), 4);
     }
 
@@ -513,13 +557,15 @@ mod tests {
         let mut seq = DataSequencer::new(StreamId(1));
 
         // Check readiness: Should only be ready when there are no unassembled chunks.
-        assert_eq!(streams1.add(Tsn(1), seq.ordered("a", "B"), &mut |_| {}), 1);
+        streams1.add(Tsn(1), seq.ordered("a", "B"), &mut |_| {});
+        assert_eq!(streams1.queued_bytes(), 1);
         assert!(
             streams1
                 .get_handover_readiness()
                 .contains(HandoverReadiness::STREAM_HAS_UNASSEMBLED_CHUNKS)
         );
-        assert_eq!(streams1.add(Tsn(2), seq.ordered("bcd", "E"), &mut |_| {}), -1);
+        streams1.add(Tsn(2), seq.ordered("bcd", "E"), &mut |_| {});
+        assert_eq!(streams1.queued_bytes(), 0);
         assert!(streams1.get_handover_readiness().is_ready());
 
         // Save and restore state
@@ -534,7 +580,8 @@ mod tests {
         let data = seq.ordered("efgh", "BE");
         assert_eq!(data.mid, Mid(1));
 
-        assert_eq!(streams2.add(Tsn(3), data, &mut |m| messages.push(m)), 0);
+        streams2.add(Tsn(3), data, &mut |m| messages.push(m));
+        assert_eq!(streams2.queued_bytes(), 0);
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].payload, b"efgh");
     }
@@ -545,13 +592,15 @@ mod tests {
         let mut seq = DataSequencer::new(StreamId(1));
 
         // Check readiness: Should only be ready when there are no unassembled chunks.
-        assert_eq!(streams1.add(Tsn(1), seq.unordered("a", "B"), &mut |_| {}), 1);
+        streams1.add(Tsn(1), seq.unordered("a", "B"), &mut |_| {});
+        assert_eq!(streams1.queued_bytes(), 1);
         assert!(
             streams1
                 .get_handover_readiness()
                 .contains(HandoverReadiness::STREAM_HAS_UNASSEMBLED_CHUNKS)
         );
-        assert_eq!(streams1.add(Tsn(2), seq.unordered("bcd", "E"), &mut |_| {}), -1);
+        streams1.add(Tsn(2), seq.unordered("bcd", "E"), &mut |_| {});
+        assert_eq!(streams1.queued_bytes(), 0);
         assert!(streams1.get_handover_readiness().is_ready());
 
         // Save and restore state
@@ -564,7 +613,8 @@ mod tests {
 
         // Verify restored state
         let data = seq.unordered("efgh", "BE");
-        assert_eq!(streams2.add(Tsn(3), data, &mut |m| messages.push(m)), 0);
+        streams2.add(Tsn(3), data, &mut |m| messages.push(m));
+        assert_eq!(streams2.queued_bytes(), 0);
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].payload, b"efgh");
     }

--- a/src/rx/mod.rs
+++ b/src/rx/mod.rs
@@ -84,6 +84,14 @@ impl<K: ReassemblyKey> IntervalList<K> {
         self.intervals.is_empty()
     }
 
+    /// Returns the total number of bytes currently buffered in the list.
+    pub fn total_bytes(&self) -> usize {
+        self.intervals
+            .iter()
+            .map(|interval| interval.payload.iter().map(|p| p.len()).sum::<usize>())
+            .sum()
+    }
+
     /// Adds a new chunk to the list, merging it with existing intervals if possible.
     ///
     /// This method expects that the data is deduplicated and sanity checked by the caller, e.g. by

--- a/src/rx/reassembly_queue.rs
+++ b/src/rx/reassembly_queue.rs
@@ -68,7 +68,7 @@ impl DerefMut for ReassemblyStrategy {
 pub struct ReassemblyQueue {
     max_size_bytes: usize,
     watermark_bytes: usize,
-    queued_bytes: usize,
+    deferred_bytes: usize,
     streams: ReassemblyStrategy,
     deferred_reset_streams: Option<DeferredResetStreams>,
     rx_messages_count: usize,
@@ -86,7 +86,7 @@ impl ReassemblyQueue {
         Self {
             max_size_bytes,
             watermark_bytes: (max_size_bytes as f32 * HIGH_WATERMARK_LIMIT) as usize,
-            queued_bytes: 0,
+            deferred_bytes: 0,
             streams,
             deferred_reset_streams: None,
             rx_messages_count: 0,
@@ -99,9 +99,7 @@ impl ReassemblyQueue {
     }
 
     pub fn get_next_message(&mut self) -> Option<Message> {
-        let message = self.reassembled_messages.pop_front()?;
-        self.queued_bytes -= message.payload.len();
-        Some(message)
+        self.reassembled_messages.pop_front()
     }
 
     pub fn rx_messages_count(&self) -> usize {
@@ -115,31 +113,30 @@ impl ReassemblyQueue {
             if tsn > deferred_stream.sender_last_assigned_tsn
                 && deferred_stream.streams.contains(&data.stream_key.id())
             {
-                self.queued_bytes += data.payload.len();
+                self.deferred_bytes += data.payload.len();
                 deferred_stream.deferred_operations.push(DeferredOperation::Data(tsn, data));
                 return;
             }
         }
 
-        let bytes_added_to_queue = self.streams.add(tsn, data, &mut |message| {
+        self.streams.add(tsn, data, &mut |message| {
             self.rx_messages_count += 1;
-            self.queued_bytes += message.payload.len();
             self.reassembled_messages.push_back(message);
         });
-
-        self.queued_bytes = self.queued_bytes.wrapping_add_signed(bytes_added_to_queue);
     }
 
     pub fn queued_bytes(&self) -> usize {
-        self.queued_bytes
+        let ready_messages_bytes: usize =
+            self.reassembled_messages.iter().map(|m| m.payload.len()).sum();
+        ready_messages_bytes + self.streams.queued_bytes() + self.deferred_bytes
     }
 
     pub fn is_above_watermark(&self) -> bool {
-        self.queued_bytes >= self.watermark_bytes
+        self.queued_bytes() >= self.watermark_bytes
     }
 
     pub fn is_full(&self) -> bool {
-        self.queued_bytes >= self.max_size_bytes
+        self.queued_bytes() >= self.max_size_bytes
     }
 
     fn forward_tsn_cost(num_streams: usize) -> usize {
@@ -153,7 +150,7 @@ impl ReassemblyQueue {
     ) {
         if let Some(deferred_stream) = &mut self.deferred_reset_streams {
             if new_cumulative_ack > deferred_stream.sender_last_assigned_tsn {
-                self.queued_bytes += ReassemblyQueue::forward_tsn_cost(skipped_streams.len());
+                self.deferred_bytes += ReassemblyQueue::forward_tsn_cost(skipped_streams.len());
                 deferred_stream
                     .deferred_operations
                     .push(DeferredOperation::ForwardTsn(new_cumulative_ack, skipped_streams));
@@ -161,18 +158,15 @@ impl ReassemblyQueue {
             }
         }
 
-        let bytes_removed_from_queue =
-            self.streams.handle_forward_tsn(new_cumulative_ack, &skipped_streams, &mut |message| {
-                self.rx_messages_count += 1;
-                self.queued_bytes += message.payload.len();
-                self.reassembled_messages.push_back(message);
-            });
-        self.queued_bytes -= bytes_removed_from_queue;
+        self.streams.handle_forward_tsn(new_cumulative_ack, &skipped_streams, &mut |message| {
+            self.rx_messages_count += 1;
+            self.reassembled_messages.push_back(message);
+        });
     }
 
     /// The remaining bytes until the queue has reached the watermark limit.
     pub fn remaining_bytes(&self) -> usize {
-        self.watermark_bytes - self.queued_bytes
+        self.watermark_bytes.saturating_sub(self.queued_bytes())
     }
 
     pub(crate) fn enter_deferred_reset(
@@ -190,10 +184,10 @@ impl ReassemblyQueue {
     pub(crate) fn reset_streams_and_leave_deferred_reset(&mut self, streams: &[StreamId]) {
         self.streams.reset_streams(streams);
         if let Some(deferred) = self.deferred_reset_streams.take() {
+            self.deferred_bytes = 0;
             deferred.deferred_operations.into_iter().for_each(|op| match op {
                 DeferredOperation::Data(tsn, data) => self.add(tsn, data),
                 DeferredOperation::ForwardTsn(tsn, skipped) => {
-                    self.queued_bytes -= ReassemblyQueue::forward_tsn_cost(skipped.len());
                     self.handle_forward_tsn(tsn, skipped);
                 }
             });
@@ -583,5 +577,67 @@ mod tests {
         // the earlier value.
         q.reset_streams_and_leave_deferred_reset(&[StreamId(1)]);
         assert_eq!(q.queued_bytes(), 0);
+    }
+
+    #[test]
+    fn traditional_reset_streams_clears_queued_bytes() {
+        let mut q = make_traditional_queue();
+        let mut seq = DataSequencer::new(StreamId(1));
+
+        q.add(Tsn(10), seq.ordered("abc", "B"));
+        assert_eq!(q.queued_bytes(), 3);
+
+        q.reset_streams_and_leave_deferred_reset(&[StreamId(1)]);
+
+        assert_eq!(q.queued_bytes(), 0);
+    }
+
+    #[test]
+    fn interleaved_reset_streams_clears_queued_bytes() {
+        let mut q = make_interleaved_queue();
+        let mut seq = DataSequencer::new(StreamId(1));
+
+        q.add(Tsn(10), seq.ordered("abc", "B"));
+        assert_eq!(q.queued_bytes(), 3);
+
+        q.reset_streams_and_leave_deferred_reset(&[StreamId(1)]);
+
+        assert_eq!(q.queued_bytes(), 0);
+    }
+
+    #[test]
+    fn watermark_straddling_does_not_underflow() {
+        let mut q = ReassemblyQueue::new(100, false); // watermark will be 90 bytes
+        let mut seq = DataSequencer::new(StreamId(1));
+
+        // Add a message that is larger than the watermark (e.g. 95 bytes)
+        q.add(Tsn(10), seq.ordered(&"a".repeat(95), "B"));
+
+        assert_eq!(q.queued_bytes(), 95);
+        assert!(q.is_above_watermark());
+
+        // Assert remaining_bytes saturates to 0 rather than underflowing/panicking
+        assert_eq!(q.remaining_bytes(), 0);
+    }
+
+    #[test]
+    fn deferred_reset_does_not_double_count_bytes() {
+        let mut q = make_traditional_queue();
+        let mut seq = DataSequencer::new(StreamId(1));
+
+        // Enter deferred reset
+        q.enter_deferred_reset(Tsn(10), &[StreamId(1)]);
+
+        // Add chunk that is deferred (not completed, B-bit only)
+        q.add(Tsn(11), seq.ordered("abc", "B"));
+
+        // Initially, the bytes should be counted as deferred bytes
+        assert_eq!(q.queued_bytes(), 3);
+
+        // Leave deferred reset (plays back the deferred chunk)
+        q.reset_streams_and_leave_deferred_reset(&[StreamId(1)]);
+
+        // The chunk should be buffered in the stream, but not double-counted
+        assert_eq!(q.queued_bytes(), 3);
     }
 }

--- a/src/rx/reassembly_streams.rs
+++ b/src/rx/reassembly_streams.rs
@@ -37,30 +37,27 @@ pub trait ReassemblyStreams {
     ///
     /// This method expects that the data is deduplicated and sanity checked by the caller, e.g. by
     /// the DataTracker.
-    ///
-    /// Returns the additional number of bytes added to the queue as a result of performing this
-    /// operation. If this addition resulted in messages being assembled and delivered, this may be
-    /// negative.
-    fn add(&mut self, tsn: Tsn, data: Data, on_reassembled: &mut dyn FnMut(Message)) -> isize;
+    fn add(&mut self, tsn: Tsn, data: Data, on_reassembled: &mut dyn FnMut(Message));
 
     /// Called for incoming FORWARD-TSN/I-FORWARD-TSN chunks - when the sender wishes the received
     /// to skip/forget about data up until the provided TSN. This is used to implement partial
     /// reliability, such as limiting the number of retransmissions or the an expiration duration.
     /// As a result of skipping data, this may result in the implementation being able to assemble
     /// messages in ordered streams.
-    ///
-    /// Returns the number of bytes removed from the queue as a result of this operation.
     fn handle_forward_tsn(
         &mut self,
         new_cumulative_ack: Tsn,
         skipped_streams: &[SkippedStream],
         on_reassembled: &mut dyn FnMut(Message),
-    ) -> usize;
+    );
 
     /// Called for incoming (possibly deferred) RE_CONFIG chunks asking for either a few streams, or
     /// all streams (when the list is empty) to be reset - to have their next SSN or Message ID to
     /// be zero.
     fn reset_streams(&mut self, streams: &[StreamId]);
+
+    /// Returns the number of bytes currently buffered in the unassembled streams.
+    fn queued_bytes(&self) -> usize;
 
     fn get_handover_readiness(&self) -> HandoverReadiness;
     fn add_to_handover_state(&self, state: &mut SocketHandoverState);

--- a/src/rx/traditional_reassembly_streams.rs
+++ b/src/rx/traditional_reassembly_streams.rs
@@ -43,17 +43,18 @@ impl ReassemblyKey for TraditionalKey {
 pub struct TraditionalReassemblyStreams {
     ordered: HashMap<StreamId, OrderedStream>,
     unordered: HashMap<StreamId, UnorderedStream>,
+    queued_bytes: usize,
 }
 
 impl TraditionalReassemblyStreams {
     pub fn new() -> Self {
-        Self { ordered: HashMap::new(), unordered: HashMap::new() }
+        Self { ordered: HashMap::new(), unordered: HashMap::new(), queued_bytes: 0 }
     }
 }
 
 impl ReassemblyStreams for TraditionalReassemblyStreams {
-    fn add(&mut self, tsn: Tsn, data: Data, on_reassembled: &mut dyn FnMut(Message)) -> isize {
-        match data.stream_key {
+    fn add(&mut self, tsn: Tsn, data: Data, on_reassembled: &mut dyn FnMut(Message)) {
+        let diff = match data.stream_key {
             StreamKey::Ordered(id) => self
                 .ordered
                 .entry(id)
@@ -64,7 +65,8 @@ impl ReassemblyStreams for TraditionalReassemblyStreams {
                 .entry(id)
                 .or_insert_with(|| UnorderedStream::new(id))
                 .add(tsn, data, on_reassembled),
-        }
+        };
+        self.queued_bytes = self.queued_bytes.strict_add_signed(diff);
     }
 
     fn handle_forward_tsn(
@@ -72,30 +74,34 @@ impl ReassemblyStreams for TraditionalReassemblyStreams {
         new_cumulative_ack: Tsn,
         skipped_streams: &[SkippedStream],
         on_reassembled: &mut dyn FnMut(Message),
-    ) -> usize {
-        let mut ret = 0;
-
+    ) {
         for stream in self.unordered.values_mut() {
-            ret += stream.erase_to(new_cumulative_ack, None::<&SkippedStream>, on_reassembled);
+            self.queued_bytes -=
+                stream.erase_to(new_cumulative_ack, None::<&SkippedStream>, on_reassembled);
         }
 
         for skipped_stream in skipped_streams {
             if let SkippedStream::ForwardTsn(stream_id, _) = skipped_stream {
-                ret += self
+                self.queued_bytes -= self
                     .ordered
                     .entry(*stream_id)
                     .or_insert_with(|| OrderedStream::new(*stream_id))
                     .erase_to(new_cumulative_ack, Some(skipped_stream), on_reassembled);
             }
         }
-        ret
     }
 
     fn reset_streams(&mut self, streams: &[StreamId]) {
-        self.ordered
-            .iter_mut()
-            .filter(|(id, _)| streams.is_empty() || streams.contains(id))
-            .for_each(|(_, stream)| stream.reset());
+        for (id, stream) in &mut self.ordered {
+            if streams.is_empty() || streams.contains(id) {
+                self.queued_bytes -= stream.intervals.total_bytes();
+                stream.reset();
+            }
+        }
+    }
+
+    fn queued_bytes(&self) -> usize {
+        self.queued_bytes
     }
 
     fn get_handover_readiness(&self) -> HandoverReadiness {
@@ -284,11 +290,15 @@ mod tests {
         let mut s = TraditionalReassemblyStreams::new();
         let mut seq = DataSequencer::new(StreamId(1));
 
-        assert_eq!(s.add(Tsn(1), seq.unordered("a", "B"), &mut |_| {}), 1);
-        assert_eq!(s.add(Tsn(2), seq.unordered("bcd", ""), &mut |_| {}), 3);
-        assert_eq!(s.add(Tsn(3), seq.unordered("ef", ""), &mut |_| {}), 2);
+        s.add(Tsn(1), seq.unordered("a", "B"), &mut |_| {});
+        assert_eq!(s.queued_bytes(), 1);
+        s.add(Tsn(2), seq.unordered("bcd", ""), &mut |_| {});
+        assert_eq!(s.queued_bytes(), 4);
+        s.add(Tsn(3), seq.unordered("ef", ""), &mut |_| {});
+        assert_eq!(s.queued_bytes(), 6);
         // Adding the end fragment should make it empty again.
-        assert_eq!(s.add(Tsn(4), seq.unordered("g", "E"), &mut |_| {}), -6);
+        s.add(Tsn(4), seq.unordered("g", "E"), &mut |_| {});
+        assert_eq!(s.queued_bytes(), 0);
     }
 
     #[test]
@@ -297,11 +307,15 @@ mod tests {
         let mut seq = DataSequencer::new(StreamId(1));
         let mut messages = Vec::new();
 
-        assert_eq!(s.add(Tsn(1), seq.unordered("a", "B"), &mut |m| messages.push(m)), 1);
-        assert_eq!(s.add(Tsn(2), seq.unordered("bcd", ""), &mut |m| messages.push(m)), 3);
-        assert_eq!(s.add(Tsn(4), seq.unordered("g", "E"), &mut |m| messages.push(m)), 1);
+        s.add(Tsn(1), seq.unordered("a", "B"), &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 1);
+        s.add(Tsn(2), seq.unordered("bcd", ""), &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 4);
+        s.add(Tsn(4), seq.unordered("g", "E"), &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 5);
         assert!(messages.is_empty());
-        assert_eq!(s.add(Tsn(3), seq.unordered("ef", ""), &mut |m| messages.push(m)), -5);
+        s.add(Tsn(3), seq.unordered("ef", ""), &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 0);
         assert_eq!(messages.len(), 1);
     }
 
@@ -311,10 +325,14 @@ mod tests {
         let mut seq = DataSequencer::new(StreamId(1));
         let mut messages = Vec::new();
 
-        assert_eq!(s.add(Tsn(1), seq.ordered("a", "B"), &mut |m| messages.push(m)), 1);
-        assert_eq!(s.add(Tsn(2), seq.ordered("bcd", ""), &mut |m| messages.push(m)), 3);
-        assert_eq!(s.add(Tsn(3), seq.ordered("ef", ""), &mut |m| messages.push(m)), 2);
-        assert_eq!(s.add(Tsn(4), seq.ordered("g", "E"), &mut |m| messages.push(m)), -6);
+        s.add(Tsn(1), seq.ordered("a", "B"), &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 1);
+        s.add(Tsn(2), seq.ordered("bcd", ""), &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 4);
+        s.add(Tsn(3), seq.ordered("ef", ""), &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 6);
+        s.add(Tsn(4), seq.ordered("g", "E"), &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 0);
         assert_eq!(messages.len(), 1);
     }
 
@@ -324,16 +342,23 @@ mod tests {
         let mut seq = DataSequencer::new(StreamId(1));
         let mut messages = Vec::new();
 
-        assert_eq!(s.add(Tsn(1), seq.ordered("a", "B"), &mut |m| messages.push(m)), 1);
+        s.add(Tsn(1), seq.ordered("a", "B"), &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 1);
         let late = seq.ordered("bcd", "");
-        assert_eq!(s.add(Tsn(3), seq.ordered("ef", ""), &mut |m| messages.push(m)), 2);
-        assert_eq!(s.add(Tsn(4), seq.ordered("g", "E"), &mut |m| messages.push(m)), 1);
+        s.add(Tsn(3), seq.ordered("ef", ""), &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 3);
+        s.add(Tsn(4), seq.ordered("g", "E"), &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 4);
 
-        assert_eq!(s.add(Tsn(5), seq.ordered("h", "BE"), &mut |m| messages.push(m)), 1);
-        assert_eq!(s.add(Tsn(6), seq.ordered("ij", "B"), &mut |m| messages.push(m)), 2);
-        assert_eq!(s.add(Tsn(7), seq.ordered("k", "E"), &mut |m| messages.push(m)), 1);
+        s.add(Tsn(5), seq.ordered("h", "BE"), &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 5);
+        s.add(Tsn(6), seq.ordered("ij", "B"), &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 7);
+        s.add(Tsn(7), seq.ordered("k", "E"), &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 8);
         assert!(messages.is_empty());
-        assert_eq!(s.add(Tsn(2), late, &mut |m| messages.push(m)), -8);
+        s.add(Tsn(2), late, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 0);
 
         assert_eq!(messages.len(), 3);
     }
@@ -344,11 +369,15 @@ mod tests {
         let mut seq = DataSequencer::new(StreamId(1));
         let mut messages = Vec::new();
 
-        assert_eq!(s.add(Tsn(1), seq.unordered("a", "B"), &mut |m| messages.push(m)), 1);
-        assert_eq!(s.add(Tsn(2), seq.unordered("bcd", ""), &mut |m| messages.push(m)), 3);
-        assert_eq!(s.add(Tsn(3), seq.unordered("ef", ""), &mut |m| messages.push(m)), 2);
+        s.add(Tsn(1), seq.unordered("a", "B"), &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 1);
+        s.add(Tsn(2), seq.unordered("bcd", ""), &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 4);
+        s.add(Tsn(3), seq.unordered("ef", ""), &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 6);
         // Adding the end fragment should make it empty again.
-        assert_eq!(s.handle_forward_tsn(Tsn(3), &[], &mut |m| messages.push(m)), 6);
+        s.handle_forward_tsn(Tsn(3), &[], &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 0);
     }
 
     #[test]
@@ -357,18 +386,17 @@ mod tests {
         let mut seq = DataSequencer::new(StreamId(1));
         let mut messages = Vec::new();
 
-        assert_eq!(s.add(Tsn(1), seq.ordered("a", "B"), &mut |m| messages.push(m)), 1);
-        assert_eq!(s.add(Tsn(2), seq.ordered("bcd", ""), &mut |m| messages.push(m)), 3);
-        assert_eq!(s.add(Tsn(3), seq.ordered("ef", ""), &mut |m| messages.push(m)), 2);
+        s.add(Tsn(1), seq.ordered("a", "B"), &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 1);
+        s.add(Tsn(2), seq.ordered("bcd", ""), &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 4);
+        s.add(Tsn(3), seq.ordered("ef", ""), &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 6);
         // Adding the end fragment should make it empty again.
-        assert_eq!(
-            s.handle_forward_tsn(
-                Tsn(3),
-                &[SkippedStream::ForwardTsn(StreamId(1), Ssn(0))],
-                &mut |m| messages.push(m)
-            ),
-            6
-        );
+        s.handle_forward_tsn(Tsn(3), &[SkippedStream::ForwardTsn(StreamId(1), Ssn(0))], &mut |m| {
+            messages.push(m);
+        });
+        assert_eq!(s.queued_bytes(), 0);
     }
 
     #[test]
@@ -377,23 +405,25 @@ mod tests {
         let mut seq = DataSequencer::new(StreamId(1));
         let mut messages = Vec::new();
 
-        assert_eq!(s.add(Tsn(1), seq.ordered("a", "B"), &mut |m| messages.push(m)), 1);
+        s.add(Tsn(1), seq.ordered("a", "B"), &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 1);
         seq.ordered("bcd", ""); // TSN=2 Not received.
-        assert_eq!(s.add(Tsn(3), seq.ordered("ef", ""), &mut |m| messages.push(m)), 2);
-        assert_eq!(s.add(Tsn(4), seq.ordered("g", "E"), &mut |m| messages.push(m)), 1);
+        s.add(Tsn(3), seq.ordered("ef", ""), &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 3);
+        s.add(Tsn(4), seq.ordered("g", "E"), &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 4);
 
-        assert_eq!(s.add(Tsn(5), seq.ordered("h", "BE"), &mut |m| messages.push(m)), 1);
-        assert_eq!(s.add(Tsn(6), seq.ordered("ij", "B"), &mut |m| messages.push(m)), 2);
-        assert_eq!(s.add(Tsn(7), seq.ordered("k", "E"), &mut |m| messages.push(m)), 1);
+        s.add(Tsn(5), seq.ordered("h", "BE"), &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 5);
+        s.add(Tsn(6), seq.ordered("ij", "B"), &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 7);
+        s.add(Tsn(7), seq.ordered("k", "E"), &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 8);
 
-        assert_eq!(
-            s.handle_forward_tsn(
-                Tsn(8),
-                &[SkippedStream::ForwardTsn(StreamId(1), Ssn(2))],
-                &mut |m| messages.push(m)
-            ),
-            8
-        );
+        s.handle_forward_tsn(Tsn(8), &[SkippedStream::ForwardTsn(StreamId(1), Ssn(2))], &mut |m| {
+            messages.push(m);
+        });
+        assert_eq!(s.queued_bytes(), 0);
     }
 
     #[test]
@@ -402,23 +432,25 @@ mod tests {
         let mut seq = DataSequencer::new(StreamId(1));
         let mut messages = Vec::new();
 
-        assert_eq!(s.add(Tsn(1), seq.ordered("a", "B"), &mut |m| messages.push(m)), 1);
+        s.add(Tsn(1), seq.ordered("a", "B"), &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 1);
         seq.ordered("bcd", ""); // TSN=2 Not received.
-        assert_eq!(s.add(Tsn(3), seq.ordered("ef", ""), &mut |m| messages.push(m)), 2);
-        assert_eq!(s.add(Tsn(4), seq.ordered("g", "E"), &mut |m| messages.push(m)), 1);
+        s.add(Tsn(3), seq.ordered("ef", ""), &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 3);
+        s.add(Tsn(4), seq.ordered("g", "E"), &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 4);
 
-        assert_eq!(s.add(Tsn(5), seq.ordered("h", "BE"), &mut |m| messages.push(m)), 1);
-        assert_eq!(s.add(Tsn(6), seq.ordered("ij", "B"), &mut |m| messages.push(m)), 2);
-        assert_eq!(s.add(Tsn(7), seq.ordered("k", "E"), &mut |m| messages.push(m)), 1);
+        s.add(Tsn(5), seq.ordered("h", "BE"), &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 5);
+        s.add(Tsn(6), seq.ordered("ij", "B"), &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 7);
+        s.add(Tsn(7), seq.ordered("k", "E"), &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 8);
 
-        assert_eq!(
-            s.handle_forward_tsn(
-                Tsn(8),
-                &[SkippedStream::ForwardTsn(StreamId(1), Ssn(0))],
-                &mut |m| messages.push(m)
-            ),
-            8
-        );
+        s.handle_forward_tsn(Tsn(8), &[SkippedStream::ForwardTsn(StreamId(1), Ssn(0))], &mut |m| {
+            messages.push(m);
+        });
+        assert_eq!(s.queued_bytes(), 0);
         assert_eq!(messages.len(), 2);
     }
 
@@ -437,10 +469,14 @@ mod tests {
         let mut s = TraditionalReassemblyStreams::new();
         s.restore_from_state(&state);
 
-        assert_eq!(s.add(Tsn(1), g1.ordered("a", "B"), &mut |m| ms.push(m)), 1);
-        assert_eq!(s.add(Tsn(2), g1.ordered("bcd", ""), &mut |m| ms.push(m)), 3);
-        assert_eq!(s.add(Tsn(3), g2.ordered("e", "B"), &mut |m| ms.push(m)), 1);
-        assert_eq!(s.add(Tsn(4), g2.ordered("fgh", ""), &mut |m| ms.push(m)), 3);
+        s.add(Tsn(1), g1.ordered("a", "B"), &mut |m| ms.push(m));
+        assert_eq!(s.queued_bytes(), 1);
+        s.add(Tsn(2), g1.ordered("bcd", ""), &mut |m| ms.push(m));
+        assert_eq!(s.queued_bytes(), 4);
+        s.add(Tsn(3), g2.ordered("e", "B"), &mut |m| ms.push(m));
+        assert_eq!(s.queued_bytes(), 5);
+        s.add(Tsn(4), g2.ordered("fgh", ""), &mut |m| ms.push(m));
+        assert_eq!(s.queued_bytes(), 8);
     }
 
     #[test]
@@ -449,20 +485,18 @@ mod tests {
         let mut g1 = DataSequencer::new(StreamId(1));
         let mut ms = Vec::<Message>::new();
 
-        assert_eq!(s.add(Tsn(1), g1.ordered("a", "B"), &mut |m| ms.push(m)), 1);
+        s.add(Tsn(1), g1.ordered("a", "B"), &mut |m| ms.push(m));
+        assert_eq!(s.queued_bytes(), 1);
         assert_eq!(s.get_handover_readiness(), HandoverReadiness::STREAM_HAS_UNASSEMBLED_CHUNKS);
-        assert_eq!(s.add(Tsn(2), g1.ordered("bcd", ""), &mut |m| ms.push(m)), 3);
+        s.add(Tsn(2), g1.ordered("bcd", ""), &mut |m| ms.push(m));
+        assert_eq!(s.queued_bytes(), 4);
         assert_eq!(s.get_handover_readiness(), HandoverReadiness::STREAM_HAS_UNASSEMBLED_CHUNKS);
 
         g1.ordered("efg", "E"); // TSN=3 Not received.
-        assert_eq!(
-            s.handle_forward_tsn(
-                Tsn(3),
-                &[SkippedStream::ForwardTsn(StreamId(1), Ssn(0))],
-                &mut |m| ms.push(m)
-            ),
-            4
-        );
+        s.handle_forward_tsn(Tsn(3), &[SkippedStream::ForwardTsn(StreamId(1), Ssn(0))], &mut |m| {
+            ms.push(m);
+        });
+        assert_eq!(s.queued_bytes(), 0);
         assert!(s.get_handover_readiness().is_ready());
 
         let mut state = SocketHandoverState::default();
@@ -471,7 +505,8 @@ mod tests {
         let mut s = TraditionalReassemblyStreams::new();
         s.restore_from_state(&state);
 
-        assert_eq!(s.add(Tsn(4), g1.ordered("h", "B"), &mut |m| ms.push(m)), 1);
+        s.add(Tsn(4), g1.ordered("h", "B"), &mut |m| ms.push(m));
+        assert_eq!(s.queued_bytes(), 1);
     }
 
     #[test]
@@ -481,16 +516,13 @@ mod tests {
         let mut messages = Vec::new();
 
         seq.ordered("abc", "BE"); // TSN=1 Not received.
-        assert_eq!(
-            s.handle_forward_tsn(
-                Tsn(1),
-                &[SkippedStream::ForwardTsn(StreamId(1), Ssn(0))],
-                &mut |m| messages.push(m)
-            ),
-            0
-        );
+        s.handle_forward_tsn(Tsn(1), &[SkippedStream::ForwardTsn(StreamId(1), Ssn(0))], &mut |m| {
+            messages.push(m);
+        });
+        assert_eq!(s.queued_bytes(), 0);
 
-        assert_eq!(s.add(Tsn(2), seq.ordered("def", "BE"), &mut |m| messages.push(m)), 0);
+        s.add(Tsn(2), seq.ordered("def", "BE"), &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 0);
         assert_eq!(messages.len(), 1);
     }
 
@@ -505,16 +537,20 @@ mod tests {
         let data3 = seq.unordered("c", "BE");
         let data4 = seq.unordered("d", "BE");
 
-        assert_eq!(s.add(Tsn(1), data1, &mut |m| messages.push(m)), 0);
+        s.add(Tsn(1), data1, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 0);
         assert_eq!(messages.len(), 1);
 
-        assert_eq!(s.add(Tsn(3), data3, &mut |m| messages.push(m)), 0);
+        s.add(Tsn(3), data3, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 0);
         assert_eq!(messages.len(), 2);
 
-        assert_eq!(s.add(Tsn(2), data2, &mut |m| messages.push(m)), 0);
+        s.add(Tsn(2), data2, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 0);
         assert_eq!(messages.len(), 3);
 
-        assert_eq!(s.add(Tsn(4), data4, &mut |m| messages.push(m)), 0);
+        s.add(Tsn(4), data4, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 0);
         assert_eq!(messages.len(), 4);
     }
 
@@ -529,16 +565,20 @@ mod tests {
         let data3 = seq.ordered("c", "BE");
         let data4 = seq.ordered("d", "BE");
 
-        assert_eq!(s.add(Tsn(1), data1, &mut |m| messages.push(m)), 0);
+        s.add(Tsn(1), data1, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 0);
         assert_eq!(messages.len(), 1);
 
-        assert_eq!(s.add(Tsn(3), data3, &mut |m| messages.push(m)), 1);
+        s.add(Tsn(3), data3, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 1);
         assert_eq!(messages.len(), 1);
 
-        assert_eq!(s.add(Tsn(2), data2, &mut |m| messages.push(m)), -1);
+        s.add(Tsn(2), data2, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 0);
         assert_eq!(messages.len(), 3);
 
-        assert_eq!(s.add(Tsn(4), data4, &mut |m| messages.push(m)), 0);
+        s.add(Tsn(4), data4, &mut |m| messages.push(m));
+        assert_eq!(s.queued_bytes(), 0);
         assert_eq!(messages.len(), 4);
     }
 }


### PR DESCRIPTION
Previously, ReassemblyQueue tracked its total buffered bytes using a  single counter, self.queued_bytes. Since this counter was manually  updated across different features (fragment arrival, deferral,  reassembly, pop/retrieval, and resets), it was complicated and fragile, which led to three bugs:

1. A large incoming fragment could push queued_bytes above  watermark_bytes. The remaining_bytes calculation could then cause integer underflow.
2. Chunks arriving during a deferred reset were counted when deferred  and then again during normal processing (double counting).
3. Clearing a stream's buffer during a reset discarded its incomplete  fragments without adjusting queued_bytes. For interleaved streams,  the unassembled intervals themselves were also leaked.

This change resolves these issues by splitting queued_bytes into three  independent parts:
- ready_messages_bytes: Computed from the list of reassembled messages.
- deferred_bytes: Tracks bytes of deferred data and TSN operations.
- streams.queued_bytes(): Tracks bytes in unassembled stream buffers.