### PR TITLE
Add more validation for FORWARD-TSN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
  - Added Verification Tag validation on incoming packets as per RFC 9260 Section 8.5.
  - Validate incoming DATA/IDATA/FORWARD-TSN/I-FORWARD-TSN chunk types match negotiated message interleaving capability.
+ - Validate incoming FORWARD-TSN/I-FORWARD-TSN to match negotiated partial reliability capability.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to
  - Account payload size of the deferred forward TSN messages.
  - Refactored ReassemblyQueue byte tracking into smaller parts, fixing integer
    underflows and double-counting bugs.
+ - Discard FORWARD-TSN with invalid TSN.
 
 ## 0.1.13 - 2026-05-20
 

--- a/src/socket/data.rs
+++ b/src/socket/data.rs
@@ -136,6 +136,11 @@ pub(crate) fn handle_forward_tsn(
     skipped_streams: Vec<SkippedStream>,
 ) {
     if let Some(tcb) = state.tcb_mut() {
+        if !tcb.data_tracker.is_tsn_valid(new_cumulative_tsn) {
+            log::warn!("Received FORWARD-TSN chunk with invalid TSN {:?}", new_cumulative_tsn);
+            return;
+        }
+
         if tcb.data_tracker.handle_forward_tsn(now, new_cumulative_tsn) {
             tcb.reassembly_queue.handle_forward_tsn(new_cumulative_tsn, skipped_streams);
         }

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -262,17 +262,22 @@ impl Socket {
         self.ctx.events.borrow_mut().add(SocketEvent::OnError(ErrorKind::PeerReported, message));
     }
 
-    fn validate_chunk_interleaving(&mut self, chunk: &Chunk) -> bool {
+    fn validate_chunk(&mut self, chunk: &Chunk) -> bool {
         if let Some(tcb) = self.state.tcb() {
             // From <https://datatracker.ietf.org/doc/html/rfc8260#section-2> and
             // <https://datatracker.ietf.org/doc/html/rfc8260#section-2.3.1>.
             let is_interleaving = tcb.capabilities.message_interleaving;
+            // From <https://datatracker.ietf.org/doc/html/rfc3758#section-3.3.1>.
+            let partial_reliability = tcb.capabilities.partial_reliability;
             let violation_reason = match chunk {
                 Chunk::Data(_) | Chunk::ForwardTsn(_) if is_interleaving => {
                     Some("DATA/FORWARD-TSN chunk received when message interleaving is negotiated")
                 }
                 Chunk::IData(_) | Chunk::IForwardTsn(_) if !is_interleaving => Some(
                     "I-DATA/I-FORWARD-TSN chunk received when message interleaving is not negotiated",
+                ),
+                Chunk::ForwardTsn(_) | Chunk::IForwardTsn(_) if !partial_reliability => Some(
+                    "FORWARD-TSN/I-FORWARD-TSN chunk received when partial reliability is not negotiated",
                 ),
                 _ => None,
             };
@@ -489,7 +494,7 @@ impl DcSctpSocket for Socket {
                     &packet.chunks,
                 );
                 for chunk in packet.chunks {
-                    if !self.validate_chunk_interleaving(&chunk) {
+                    if !self.validate_chunk(&chunk) {
                         break;
                     }
                     match chunk {

--- a/src/socket/socket_tests.rs
+++ b/src/socket/socket_tests.rs
@@ -4036,4 +4036,30 @@ mod tests {
 
         assert_aborted_with_protocol_violation(&mut socket_a, &options);
     }
+
+    #[test]
+    fn handle_forward_tsn_without_partial_reliability_aborts() {
+        let mut options_a = default_options();
+        options_a.enable_partial_reliability = false;
+        let mut socket_a = Socket::new("A", &options_a);
+        let mut socket_z = Socket::new("Z", &default_options());
+        connect_sockets(&mut socket_a, &mut socket_z);
+
+        // Forge a FORWARD-TSN packet with a dummy TSN.
+        let packet = SctpPacketBuilder::new(
+            socket_a.verification_tag(),
+            options_a.local_port,
+            options_a.remote_port,
+            options_a.mtu,
+        )
+        .add(&Chunk::ForwardTsn(ForwardTsnChunk {
+            new_cumulative_tsn: Tsn(10),
+            skipped_streams: vec![],
+        }))
+        .build();
+
+        socket_a.handle_input(&packet);
+
+        assert_aborted_with_protocol_violation(&mut socket_a, &options_a);
+    }
 }

--- a/src/socket/socket_tests.rs
+++ b/src/socket/socket_tests.rs
@@ -4062,4 +4062,48 @@ mod tests {
 
         assert_aborted_with_protocol_violation(&mut socket_a, &options_a);
     }
+
+    #[test]
+    fn handle_forward_tsn_rejects_invalid_tsn() {
+        let options = default_options();
+        let mut socket_a = Socket::new("A", &options);
+        let mut socket_z = Socket::new("Z", &options);
+        connect_sockets(&mut socket_a, &mut socket_z);
+
+        // Z sends a message to A. Capture the legitimate DATA chunk.
+        socket_z
+            .send(Message::new(StreamId(1), PpId(51), b"hello".to_vec()), &SendOptions::default())
+            .unwrap();
+        let packet_bytes = expect_sent_packet!(socket_z.poll_event());
+        let packet = SctpPacket::from_bytes(&packet_bytes, &options).unwrap();
+        let Chunk::Data(data_chunk) = &packet.chunks[0] else {
+            panic!("Expected Data chunk");
+        };
+        let valid_tsn = data_chunk.tsn;
+
+        // Forge a FORWARD-TSN packet with a TSN far outside the outstanding window.
+        let invalid_tsn = valid_tsn + 200_000;
+        let forward_tsn_packet = SctpPacketBuilder::new(
+            socket_a.verification_tag(),
+            options.local_port,
+            options.remote_port,
+            options.mtu,
+        )
+        .add(&Chunk::ForwardTsn(ForwardTsnChunk {
+            new_cumulative_tsn: invalid_tsn,
+            skipped_streams: vec![],
+        }))
+        .build();
+
+        socket_a.handle_input(&forward_tsn_packet);
+
+        // Feed the legitimate DATA packet to A.
+        socket_a.handle_input(&packet_bytes);
+
+        // Verify that A successfully received and reassembled the message.
+        // If the invalid FORWARD-TSN had been processed, the cumulative ack TSN
+        // would have jumped, and this legitimate DATA packet would have been dropped as duplicate.
+        let msg = socket_a.get_next_message().expect("Message should be received");
+        assert_eq!(msg.payload, b"hello");
+    }
 }


### PR DESCRIPTION
This pull requests adds two validations, both for FORWARD-TSN/I-FORWARD-TSN:

 * That a FORWARD-TSN/I-FORWARD-TSN is only accepted if PR-SCTP (partial reliability SCTP extension) has been negotiated
 * That the TSN in those chunks are reasonable.