### PR TITLE
Avoid panic on unordered interleaved streams when receiving crafted MIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to
  - Discard FORWARD-TSN with invalid TSN.
  - Stop heartbeat timeout only after validating nonce in HEARTBEAT-ACK.
  - Dropping/truncating oversized Unrecognized or HEARTBEAT chunks.
+ - Avoid panic on unordered interleaved streams when receiving crafted MIDs.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to
  - Stop heartbeat timeout only after validating nonce in HEARTBEAT-ACK.
  - Dropping/truncating oversized Unrecognized or HEARTBEAT chunks.
 
+### Changed
+
+ - Refactored RFC1982 serial number types.
+
 ## 0.1.13 - 2026-05-20
 
 ### Fixed

--- a/src/rx/data_tracker.rs
+++ b/src/rx/data_tracker.rs
@@ -127,10 +127,13 @@ impl DataTracker {
     }
 
     fn add_additional_tsn(&mut self, tsn: Tsn) -> bool {
-        let idx = self.additional_tsn_blocks.partition_point(|r| r.start <= tsn);
+        let idx = self.additional_tsn_blocks.partition_point(|r| r.start.less_than_or_equal(tsn));
 
         // Check if it's a duplicate in the block before insertion point.
-        if idx > 0 && self.additional_tsn_blocks[idx - 1].contains(&tsn) {
+        if idx > 0
+            && (self.additional_tsn_blocks[idx - 1].start.less_than_or_equal(tsn)
+                && tsn.less_than(self.additional_tsn_blocks[idx - 1].end))
+        {
             return false;
         }
 
@@ -170,7 +173,7 @@ impl DataTracker {
         debug_assert!(self.is_tsn_valid(tsn));
 
         // Old chunk already seen before?
-        if tsn <= self.last_cumulative_acked_tsn {
+        if tsn.less_than_or_equal(self.last_cumulative_acked_tsn) {
             self.maybe_add_duplicate_tsn(tsn);
             is_duplicate = true;
         } else if tsn == self.last_cumulative_acked_tsn + 1 {
@@ -246,7 +249,7 @@ impl DataTracker {
         // not received at all) data, up until `new_cumulative_ack`.
 
         // Old chunk already seen before?
-        if new_cumulative_tsn <= self.last_cumulative_acked_tsn {
+        if new_cumulative_tsn.less_than_or_equal(self.last_cumulative_acked_tsn) {
             // From <https://datatracker.ietf.org/doc/html/rfc3758#section-3.6>:
             //
             //   Note, if the "New Cumulative TSN" value carried in the arrived FORWARD TSN chunk is
@@ -267,10 +270,10 @@ impl DataTracker {
         // If there have been prior gaps that are now overlapping with the new value, remove them.
         self.last_cumulative_acked_tsn = new_cumulative_tsn;
         self.additional_tsn_blocks.retain_mut(|b| {
-            if b.end <= new_cumulative_tsn {
+            if b.end.less_than_or_equal(new_cumulative_tsn) {
                 false
             } else {
-                if b.start <= new_cumulative_tsn {
+                if b.start.less_than_or_equal(new_cumulative_tsn) {
                     b.start = new_cumulative_tsn + 1;
                 }
                 true

--- a/src/rx/data_tracker.rs
+++ b/src/rx/data_tracker.rs
@@ -19,6 +19,7 @@ use crate::api::handover::SocketHandoverState;
 use crate::packet::sack_chunk::GapAckBlock;
 use crate::packet::sack_chunk::SackChunk;
 use crate::timer::Timer;
+use crate::types::SerialNumber;
 use crate::types::Tsn;
 use std::cmp::min;
 use std::ops::Range;

--- a/src/rx/interleaved_reassembly_streams.rs
+++ b/src/rx/interleaved_reassembly_streams.rs
@@ -25,6 +25,7 @@ use crate::rx::ReassemblyKey;
 use crate::rx::reassembly_streams::ReassemblyStreams;
 use crate::types::Fsn;
 use crate::types::Mid;
+use crate::types::SerialNumber;
 use crate::types::StreamKey;
 use crate::types::Tsn;
 use std::collections::HashMap;
@@ -71,8 +72,8 @@ impl OrderedStream {
     }
 
     fn add(&mut self, data: Data, on_reassembled: &mut dyn FnMut(Message)) -> isize {
-        if data.mid < self.next_mid {
-            // Already delivered or skipped.
+        if data.mid != self.next_mid && !data.mid.greater_than(self.next_mid) {
+            // Already delivered, skipped, or ambiguously too far ahead.
             return 0;
         }
 

--- a/src/rx/interleaved_reassembly_streams.rs
+++ b/src/rx/interleaved_reassembly_streams.rs
@@ -74,6 +74,35 @@ impl ReassemblyKey for InterleavedKey {
     }
 }
 
+/// A reassembly key for unordered interleaved streams that derives standard linear ordering.
+///
+/// Unordered streams accept chunks with arbitrary MIDs without discarding them based on
+/// sequence bounds. To safely store these in an `IntervalList` (which requires a strict
+/// total order for binary search), bypass RFC1982 ordering and use standard sorting instead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnorderedInterleavedKey {
+    pub mid: Mid,
+    pub fsn: Fsn,
+}
+
+impl PartialOrd for UnorderedInterleavedKey {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for UnorderedInterleavedKey {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.mid.0.cmp(&other.mid.0).then_with(|| self.fsn.0.cmp(&other.fsn.0))
+    }
+}
+
+impl ReassemblyKey for UnorderedInterleavedKey {
+    fn next(&self) -> Self {
+        UnorderedInterleavedKey { mid: self.mid, fsn: self.fsn + 1 }
+    }
+}
+
 pub struct OrderedStream {
     stream_id: StreamId,
     intervals: IntervalList<InterleavedKey>,
@@ -127,7 +156,7 @@ impl OrderedStream {
 
 pub struct UnorderedStream {
     stream_id: StreamId,
-    intervals: IntervalList<InterleavedKey>,
+    intervals: IntervalList<UnorderedInterleavedKey>,
 }
 
 impl UnorderedStream {
@@ -142,7 +171,7 @@ impl UnorderedStream {
             return 0;
         }
 
-        let key = InterleavedKey { mid: data.mid, fsn: data.fsn };
+        let key = UnorderedInterleavedKey { mid: data.mid, fsn: data.fsn };
         let queued_bytes = data.payload.len() as isize;
         let idx = self.intervals.add(key, data);
 
@@ -652,5 +681,23 @@ mod tests {
         assert_eq!(streams2.queued_bytes(), 0);
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].payload, b"efgh");
+    }
+
+    #[test]
+    fn unordered_interleaved_streams_support_extreme_mid_distances() {
+        let mut streams = InterleavedReassemblyStreams::new();
+        let mut seq = DataSequencer::new(StreamId(1));
+
+        let mut data1 = seq.unordered("a", "B");
+        data1.mid = Mid(0);
+        streams.add(Tsn(1), data1, &mut |_| {});
+
+        let mut data2 = seq.unordered("b", "B");
+        data2.mid = Mid(1 << 31);
+        streams.add(Tsn(2), data2, &mut |_| {});
+
+        // Ensure that binary search invariants in IntervalList are maintained
+        // even when receiving MIDs exactly at the maximum sequence distance.
+        assert_eq!(streams.queued_bytes(), 2);
     }
 }

--- a/src/rx/interleaved_reassembly_streams.rs
+++ b/src/rx/interleaved_reassembly_streams.rs
@@ -30,10 +30,42 @@ use crate::types::StreamKey;
 use crate::types::Tsn;
 use std::collections::HashMap;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+/// A key used to sort chunks in the interleaved reassembly queue.
+///
+/// While RFC1982 arithmetic violates transitivity rules over the full circular sequence
+/// space, it's safe to implement and use `Ord`/`PartialOrd` in sorted containers here because
+/// we limit the "active" number space to half of the full range (the forward half-space).
+/// This restricts the elements to a slice of the circular number space where the math
+/// never wraps around, allowing sorting to happen safely. Within this restricted window,
+/// the sequence numbers do form a strict, transitive total order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct InterleavedKey {
     pub mid: Mid, // Primary sort key
     pub fsn: Fsn, // Secondary sort key
+}
+
+impl PartialOrd for InterleavedKey {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for InterleavedKey {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        if self.mid == other.mid {
+            if self.fsn == other.fsn {
+                std::cmp::Ordering::Equal
+            } else if other.fsn.greater_than(self.fsn) {
+                std::cmp::Ordering::Less
+            } else {
+                std::cmp::Ordering::Greater
+            }
+        } else if other.mid.greater_than(self.mid) {
+            std::cmp::Ordering::Less
+        } else {
+            std::cmp::Ordering::Greater
+        }
+    }
 }
 
 impl ReassemblyKey for InterleavedKey {
@@ -172,10 +204,11 @@ impl ReassemblyStreams for InterleavedReassemblyStreams {
                             .entry(*stream_id)
                             .or_insert_with(|| OrderedStream::new(*stream_id, Mid(0)));
 
-                        self.queued_bytes -=
-                            stream.intervals.retain(|interval| interval.start.mid > *mid);
+                        self.queued_bytes -= stream
+                            .intervals
+                            .retain(|interval| interval.start.mid.greater_than(*mid));
 
-                        if stream.next_mid <= *mid {
+                        if stream.next_mid.less_than_or_equal(*mid) {
                             stream.next_mid = *mid + 1;
                         }
 
@@ -188,8 +221,9 @@ impl ReassemblyStreams for InterleavedReassemblyStreams {
                             .entry(*stream_id)
                             .or_insert_with(|| UnorderedStream::new(*stream_id));
 
-                        self.queued_bytes -=
-                            stream.intervals.retain(|interval| interval.start.mid > *mid);
+                        self.queued_bytes -= stream
+                            .intervals
+                            .retain(|interval| interval.start.mid.greater_than(*mid));
                     }
                 }
             }

--- a/src/rx/mod.rs
+++ b/src/rx/mod.rs
@@ -214,11 +214,30 @@ mod tests {
     use super::*;
     use crate::api::StreamId;
     use crate::testing::data_sequencer::DataSequencer;
+    use crate::types::SerialNumber;
     use crate::types::Tsn;
 
     // A simple key that wraps around a TSN, which wraps around at u32::MAX.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     struct TestKey(Tsn);
+
+    impl PartialOrd for TestKey {
+        fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+            Some(self.cmp(other))
+        }
+    }
+
+    impl Ord for TestKey {
+        fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+            if self.0 == other.0 {
+                std::cmp::Ordering::Equal
+            } else if other.0.greater_than(self.0) {
+                std::cmp::Ordering::Less
+            } else {
+                std::cmp::Ordering::Greater
+            }
+        }
+    }
 
     impl ReassemblyKey for TestKey {
         fn next(&self) -> Self {

--- a/src/rx/reassembly_queue.rs
+++ b/src/rx/reassembly_queue.rs
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 use crate::api::Message;
 use crate::api::StreamId;
 use crate::api::handover::HandoverReadiness;
@@ -21,6 +20,7 @@ use crate::packet::data::Data;
 use crate::rx::interleaved_reassembly_streams::InterleavedReassemblyStreams;
 use crate::rx::reassembly_streams::ReassemblyStreams;
 use crate::rx::traditional_reassembly_streams::TraditionalReassemblyStreams;
+use crate::types::SerialNumber;
 use crate::types::Tsn;
 use std::collections::HashSet;
 use std::collections::VecDeque;
@@ -110,7 +110,7 @@ impl ReassemblyQueue {
     /// sanity checked by the caller, e.g. by the DataTracker.
     pub fn add(&mut self, tsn: Tsn, data: Data) {
         if let Some(deferred_stream) = &mut self.deferred_reset_streams {
-            if tsn > deferred_stream.sender_last_assigned_tsn
+            if tsn.greater_than(deferred_stream.sender_last_assigned_tsn)
                 && deferred_stream.streams.contains(&data.stream_key.id())
             {
                 self.deferred_bytes += data.payload.len();
@@ -149,7 +149,7 @@ impl ReassemblyQueue {
         skipped_streams: Vec<SkippedStream>,
     ) {
         if let Some(deferred_stream) = &mut self.deferred_reset_streams {
-            if new_cumulative_ack > deferred_stream.sender_last_assigned_tsn {
+            if new_cumulative_ack.greater_than(deferred_stream.sender_last_assigned_tsn) {
                 self.deferred_bytes += ReassemblyQueue::forward_tsn_cost(skipped_streams.len());
                 deferred_stream
                     .deferred_operations

--- a/src/rx/traditional_reassembly_streams.rs
+++ b/src/rx/traditional_reassembly_streams.rs
@@ -29,10 +29,42 @@ use crate::types::StreamKey;
 use crate::types::Tsn;
 use std::collections::HashMap;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+/// A key used to sort chunks in the reassembly queue.
+///
+/// While RFC1982 arithmetic violates transitivity rules over the full circular sequence
+/// space, it's safe to implement and use `Ord`/`PartialOrd` in sorted containers here because
+/// we limit the "active" number space to half of the full range (the forward half-space).
+/// This restricts the elements to a slice of the circular number space where the math
+/// never wraps around, allowing sorting to happen safely. Within this restricted window,
+/// the sequence numbers do form a strict, transitive total order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TraditionalKey {
     pub ssn: Ssn, // Primary sort key, NOTE: Is always 0 for unordered chunks.
     pub tsn: Tsn, // Secondary sort key.
+}
+
+impl PartialOrd for TraditionalKey {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for TraditionalKey {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        if self.ssn == other.ssn {
+            if self.tsn == other.tsn {
+                std::cmp::Ordering::Equal
+            } else if other.tsn.greater_than(self.tsn) {
+                std::cmp::Ordering::Less
+            } else {
+                std::cmp::Ordering::Greater
+            }
+        } else if other.ssn.greater_than(self.ssn) {
+            std::cmp::Ordering::Less
+        } else {
+            std::cmp::Ordering::Greater
+        }
+    }
 }
 
 impl ReassemblyKey for TraditionalKey {
@@ -168,7 +200,7 @@ impl UnorderedStream {
         _: Option<&SkippedStream>,
         _: &mut dyn FnMut(Message),
     ) -> usize {
-        self.intervals.retain(|interval| interval.start.tsn > new_cumulative_ack)
+        self.intervals.retain(|interval| interval.start.tsn.greater_than(new_cumulative_ack))
     }
 
     fn reset(&mut self) {
@@ -252,9 +284,10 @@ impl OrderedStream {
     ) -> usize {
         match skipped_stream {
             Some(SkippedStream::ForwardTsn(_, ssn)) => {
-                let mut removed_bytes = self.intervals.retain(|interval| interval.start.ssn > *ssn);
+                let mut removed_bytes =
+                    self.intervals.retain(|interval| interval.start.ssn.greater_than(*ssn));
 
-                if *ssn >= self.next_ssn {
+                if ssn.greater_than_or_equal(self.next_ssn) {
                     self.next_ssn = *ssn + 1;
                 }
                 removed_bytes += self.try_to_assemble_messages(on_reassembled);

--- a/src/rx/traditional_reassembly_streams.rs
+++ b/src/rx/traditional_reassembly_streams.rs
@@ -23,6 +23,7 @@ use crate::packet::data::Data;
 use crate::rx::IntervalList;
 use crate::rx::ReassemblyKey;
 use crate::rx::reassembly_streams::ReassemblyStreams;
+use crate::types::SerialNumber;
 use crate::types::Ssn;
 use crate::types::StreamKey;
 use crate::types::Tsn;
@@ -223,8 +224,8 @@ impl OrderedStream {
 
 impl OrderedStream {
     fn add(&mut self, tsn: Tsn, data: Data, on_reassembled: &mut dyn FnMut(Message)) -> isize {
-        if data.ssn < self.next_ssn {
-            // Already delivered or skipped.
+        if data.ssn != self.next_ssn && !data.ssn.greater_than(self.next_ssn) {
+            // Already delivered, skipped, or ambiguously too far ahead.
             return 0;
         }
 

--- a/src/socket/stream_reset.rs
+++ b/src/socket/stream_reset.rs
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 use crate::api::ErrorKind;
 use crate::api::ResetStreamsError;
 use crate::api::SocketEvent;
@@ -29,6 +28,7 @@ use crate::socket::state::State;
 use crate::socket::transmission_control_block::CurrentResetRequest;
 use crate::socket::transmission_control_block::InflightResetRequest;
 use crate::socket::transmission_control_block::TransmissionControlBlock;
+use crate::types::SerialNumber;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ReqSeqNbrValidationResult {
@@ -151,34 +151,36 @@ fn handle_outgoing_reset_request(
     }
 
     tcb.last_processed_req_seq_nbr = req.request_seq_nbr;
-    tcb.last_processed_req_result =
-        if req.sender_last_assigned_tsn > tcb.data_tracker.last_cumulative_acked_tsn() {
-            // From <https://datatracker.ietf.org/doc/html/rfc6525#section-5.2.2>:
-            //
-            //   E2: If the Sender's Last Assigned TSN is greater than the
-            //   cumulative acknowledgment point, then the endpoint MUST enter
-            //   "deferred reset processing".
-            //
-            //   [...] If the endpoint enters "deferred reset processing", it MUST
-            //   put a Re-configuration Response Parameter into a RE-CONFIG chunk
-            //   indicating "In progress" and MUST send the RE-CONFIG chunk.
-            tcb.reassembly_queue.enter_deferred_reset(req.sender_last_assigned_tsn, &req.streams);
-            ReconfigurationResponseResult::InProgress
-        } else {
-            // From <https://datatracker.ietf.org/doc/html/rfc6525#section-5.2.2>:
-            //
-            //   E3: If no stream numbers are listed in the parameter, then all
-            //   incoming streams MUST be reset to 0 as the next expected SSN. If
-            //   specific stream numbers are listed, then only these specific
-            //   streams MUST be reset to 0, and all other non-listed SSNs remain
-            //   unchanged.
-            //
-            //   E4: Any queued TSNs (queued at step E2) MUST now be released and
-            //   processed normally."
-            tcb.reassembly_queue.reset_streams_and_leave_deferred_reset(&req.streams);
-            ctx.events.borrow_mut().add(SocketEvent::OnIncomingStreamReset(req.streams));
-            ReconfigurationResponseResult::SuccessPerformed
-        };
+    tcb.last_processed_req_result = if req
+        .sender_last_assigned_tsn
+        .greater_than(tcb.data_tracker.last_cumulative_acked_tsn())
+    {
+        // From <https://datatracker.ietf.org/doc/html/rfc6525#section-5.2.2>:
+        //
+        //   E2: If the Sender's Last Assigned TSN is greater than the
+        //   cumulative acknowledgment point, then the endpoint MUST enter
+        //   "deferred reset processing".
+        //
+        //   [...] If the endpoint enters "deferred reset processing", it MUST
+        //   put a Re-configuration Response Parameter into a RE-CONFIG chunk
+        //   indicating "In progress" and MUST send the RE-CONFIG chunk.
+        tcb.reassembly_queue.enter_deferred_reset(req.sender_last_assigned_tsn, &req.streams);
+        ReconfigurationResponseResult::InProgress
+    } else {
+        // From <https://datatracker.ietf.org/doc/html/rfc6525#section-5.2.2>:
+        //
+        //   E3: If no stream numbers are listed in the parameter, then all
+        //   incoming streams MUST be reset to 0 as the next expected SSN. If
+        //   specific stream numbers are listed, then only these specific
+        //   streams MUST be reset to 0, and all other non-listed SSNs remain
+        //   unchanged.
+        //
+        //   E4: Any queued TSNs (queued at step E2) MUST now be released and
+        //   processed normally."
+        tcb.reassembly_queue.reset_streams_and_leave_deferred_reset(&req.streams);
+        ctx.events.borrow_mut().add(SocketEvent::OnIncomingStreamReset(req.streams));
+        ReconfigurationResponseResult::SuccessPerformed
+    };
     responses.push(Parameter::ReconfigurationResponse(ReconfigurationResponseParameter {
         response_seq_nbr: req.request_seq_nbr,
         result: tcb.last_processed_req_result,

--- a/src/tx/outstanding_data.rs
+++ b/src/tx/outstanding_data.rs
@@ -23,6 +23,7 @@ use crate::packet::iforward_tsn_chunk::IForwardTsnChunk;
 use crate::packet::sack_chunk::GapAckBlock;
 use crate::types::Mid;
 use crate::types::OutgoingMessageId;
+use crate::types::SerialNumber;
 use crate::types::Ssn;
 use crate::types::StreamKey;
 use crate::types::Tsn;

--- a/src/tx/outstanding_data.rs
+++ b/src/tx/outstanding_data.rs
@@ -27,7 +27,7 @@ use crate::types::SerialNumber;
 use crate::types::Ssn;
 use crate::types::StreamKey;
 use crate::types::Tsn;
-use std::cmp::max;
+use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::collections::VecDeque;
@@ -107,6 +107,34 @@ pub(crate) struct AckInfo {
 
     /// The set of lifecycle IDs that were acked, but had been abandoned.
     pub abandoned_lifecycle_ids: Vec<LifecycleId>,
+}
+
+/// A wrapper around a TSN that implements `Ord` and `PartialOrd`.
+///
+/// While RFC1982 arithmetic violates transitivity rules over the full circular sequence
+/// space, it's safe to implement and use `Ord`/`PartialOrd` in sorted containers here because
+/// we limit the "active" number space to half of the full range (the forward half-space).
+/// This restricts the elements to a slice of the circular number space where the sequence numbers
+/// do form a strict, transitive total order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct OrderedTsn(pub Tsn);
+
+impl PartialOrd for OrderedTsn {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for OrderedTsn {
+    fn cmp(&self, other: &Self) -> Ordering {
+        if self.0 == other.0 {
+            Ordering::Equal
+        } else if other.0.greater_than(self.0) {
+            Ordering::Less
+        } else {
+            Ordering::Greater
+        }
+    }
 }
 
 /// State for DATA chunks (message fragments) in the queue - used in tests.
@@ -268,9 +296,9 @@ pub(crate) struct OutstandingData {
     // Payload, padding and DATA headers.
     unacked_packet_bytes: usize,
     unacked_items: usize,
-    to_be_fast_retransmitted: BTreeSet<Tsn>,
-    to_be_retransmitted: BTreeSet<Tsn>,
-    stream_reset_breakpoint_tsns: BTreeSet<Tsn>,
+    to_be_fast_retransmitted: BTreeSet<OrderedTsn>,
+    to_be_retransmitted: BTreeSet<OrderedTsn>,
+    stream_reset_breakpoint_tsns: BTreeSet<OrderedTsn>,
     unsent_messages_to_discard: Vec<(StreamId, OutgoingMessageId)>,
 }
 
@@ -297,7 +325,8 @@ impl OutstandingData {
         gap_ack_blocks: &[GapAckBlock],
         is_in_fast_recovery: bool,
     ) -> AckInfo {
-        let cumulative_tsn_ack_advanced = cumulative_tsn_ack > self.last_cumulative_tsn_ack;
+        let cumulative_tsn_ack_advanced =
+            cumulative_tsn_ack.greater_than(self.last_cumulative_tsn_ack);
 
         let mut ack_info = AckInfo {
             highest_tsn_acked: cumulative_tsn_ack,
@@ -326,7 +355,8 @@ impl OutstandingData {
     }
 
     fn remove_acked(&mut self, cumulative_tsn_ack: Tsn, ack_info: &mut AckInfo) {
-        while !self.outstanding_data.is_empty() && self.last_cumulative_tsn_ack < cumulative_tsn_ack
+        while !self.outstanding_data.is_empty()
+            && self.last_cumulative_tsn_ack.less_than(cumulative_tsn_ack)
         {
             let tsn = self.last_cumulative_tsn_ack + 1;
             self.ack_chunk(tsn, ack_info);
@@ -345,7 +375,7 @@ impl OutstandingData {
             self.outstanding_data.pop_front();
             self.last_cumulative_tsn_ack += 1;
         }
-        self.stream_reset_breakpoint_tsns.retain(|b| *b > cumulative_tsn_ack + 1);
+        self.stream_reset_breakpoint_tsns.retain(|b| b.0.greater_than(cumulative_tsn_ack + 1));
     }
 
     fn ack_gap_blocks(
@@ -364,9 +394,13 @@ impl OutstandingData {
         for block in gap_ack_blocks {
             let start = cumulative_tsn_ack.add_to(block.start as u32);
             let end = cumulative_tsn_ack.add_to(block.end as u32);
-            let start = start.max(self.last_cumulative_tsn_ack + 1);
+            let start = if start.greater_than(self.last_cumulative_tsn_ack + 1) {
+                start
+            } else {
+                self.last_cumulative_tsn_ack + 1
+            };
             let mut tsn = start;
-            while tsn <= end && tsn < self.next_tsn() {
+            while tsn.less_than_or_equal(end) && tsn.less_than(self.next_tsn()) {
                 self.ack_chunk(tsn, ack_info);
                 tsn += 1;
             }
@@ -408,11 +442,18 @@ impl OutstandingData {
         let mut prev_block_last_acked = cumulative_tsn_ack;
         for block in gap_ack_blocks {
             let cur_block_first_acked = cumulative_tsn_ack.add_to(block.start as u32);
-            let mut tsn = prev_block_last_acked.max(self.last_cumulative_tsn_ack) + 1;
+            let mut tsn = (if prev_block_last_acked.greater_than(self.last_cumulative_tsn_ack) {
+                prev_block_last_acked
+            } else {
+                self.last_cumulative_tsn_ack
+            }) + 1;
             let limit = self.next_tsn();
             // TSN comparisons lack transitivity; each upper bound must be evaluated individually to
             // safely handle serial arithmetic wrapping.
-            while tsn < cur_block_first_acked && tsn <= max_tsn_to_nack && tsn < limit {
+            while tsn.less_than(cur_block_first_acked)
+                && tsn.less_than_or_equal(max_tsn_to_nack)
+                && tsn.less_than(limit)
+            {
                 ack_info.has_packet_loss |= self.nack_chunk(tsn, false, !is_in_fast_recovery);
                 tsn += 1;
             }
@@ -443,9 +484,9 @@ impl OutstandingData {
             NackAction::Retransmit => {
                 debug_assert!(matches!(item.state, ItemState::QueuedForRetransmission { .. }));
                 if do_fast_retransmit {
-                    self.to_be_fast_retransmitted.insert(tsn);
+                    self.to_be_fast_retransmitted.insert(OrderedTsn(tsn));
                 } else {
-                    self.to_be_retransmitted.insert(tsn);
+                    self.to_be_retransmitted.insert(OrderedTsn(tsn));
                 }
                 true
             }
@@ -470,11 +511,15 @@ impl OutstandingData {
                 self.unacked_items -= 1;
             }
             if item.should_be_retransmitted() {
-                self.to_be_retransmitted.remove(&tsn);
-                self.to_be_fast_retransmitted.remove(&tsn);
+                self.to_be_retransmitted.remove(&OrderedTsn(tsn));
+                self.to_be_fast_retransmitted.remove(&OrderedTsn(tsn));
             }
             item.ack();
-            ack_info.highest_tsn_acked = max(ack_info.highest_tsn_acked, tsn);
+            ack_info.highest_tsn_acked = if tsn.greater_than(ack_info.highest_tsn_acked) {
+                tsn
+            } else {
+                ack_info.highest_tsn_acked
+            };
         }
     }
 
@@ -490,11 +535,11 @@ impl OutstandingData {
         &mut self,
         now: SocketTime,
         mut max_size: usize,
-        tsns: &mut BTreeSet<Tsn>,
+        tsns: &mut BTreeSet<OrderedTsn>,
     ) -> Vec<(Tsn, Data)> {
         let mut result: Vec<(Tsn, Data)> = vec![];
         for tsn in tsns.iter() {
-            let index = tsn.distance_to(self.last_cumulative_tsn_ack) - 1;
+            let index = tsn.0.distance_to(self.last_cumulative_tsn_ack) - 1;
             let item = self.outstanding_data.get_mut(index as usize).unwrap();
 
             debug_assert!(item.should_be_retransmitted());
@@ -505,7 +550,7 @@ impl OutstandingData {
             let size = round_up_to_4!(self.data_chunk_header_size + item.data.payload.len());
             if size <= max_size {
                 item.mark_as_retransmitted(now);
-                result.push((*tsn, item.data.clone()));
+                result.push((tsn.0, item.data.clone()));
                 max_size -= size;
                 self.unacked_payload_bytes += item.data.payload.len();
                 self.unacked_packet_bytes += size;
@@ -516,7 +561,7 @@ impl OutstandingData {
             }
         }
         for (tsn, _) in &result {
-            tsns.remove(tsn);
+            tsns.remove(&OrderedTsn(*tsn));
         }
         result
     }
@@ -538,7 +583,7 @@ impl OutstandingData {
         //   fit in the sent datagram carrying K other TSNs are also marked as ineligible for a
         //   subsequent Fast Retransmit. However, as they are marked for retransmission, they will
         //   be retransmitted later on as soon as cwnd allows."
-        self.to_be_retransmitted.append(&mut tsns);
+        self.to_be_retransmitted.extend(tsns);
         chunks
     }
 
@@ -690,8 +735,8 @@ impl OutstandingData {
                 if !other.is_abandoned() {
                     let was_outstanding = other.is_outstanding();
                     if other.should_be_retransmitted() {
-                        self.to_be_fast_retransmitted.remove(&tsn);
-                        self.to_be_retransmitted.remove(&tsn);
+                        self.to_be_fast_retransmitted.remove(&OrderedTsn(tsn));
+                        self.to_be_retransmitted.remove(&OrderedTsn(tsn));
                     }
                     other.abandon();
                     if was_outstanding {
@@ -754,7 +799,7 @@ impl OutstandingData {
         let mut tsn = self.last_cumulative_tsn_ack;
         for item in &self.outstanding_data {
             tsn += 1;
-            if self.stream_reset_breakpoint_tsns.contains(&tsn)
+            if self.stream_reset_breakpoint_tsns.contains(&OrderedTsn(tsn))
                 || tsn != new_cumulative_tsn + 1
                 || !item.is_abandoned()
             {
@@ -765,7 +810,7 @@ impl OutstandingData {
             if item.data.stream_key.is_ordered() {
                 let entry =
                     skipped_per_ordered_stream.entry(item.data.stream_key.id()).or_insert(Ssn(0));
-                if item.data.ssn > *entry {
+                if item.data.ssn.greater_than(*entry) {
                     *entry = item.data.ssn;
                 }
             }
@@ -787,7 +832,7 @@ impl OutstandingData {
         let mut tsn = self.last_cumulative_tsn_ack;
         for item in &self.outstanding_data {
             tsn += 1;
-            if self.stream_reset_breakpoint_tsns.contains(&tsn)
+            if self.stream_reset_breakpoint_tsns.contains(&OrderedTsn(tsn))
                 || tsn != new_cumulative_tsn + 1
                 || !item.is_abandoned()
             {
@@ -796,7 +841,7 @@ impl OutstandingData {
             new_cumulative_tsn = tsn;
 
             let entry = skipped_per_stream.entry(item.data.stream_key).or_insert(Mid(0));
-            if item.data.mid > *entry {
+            if item.data.mid.greater_than(*entry) {
                 *entry = item.data.mid;
             }
         }
@@ -813,7 +858,7 @@ impl OutstandingData {
     /// sent and now. It takes into account Karn's algorithm, so if the chunk has ever been
     /// retransmitted, it will return `None`.
     pub fn measure_rtt(&mut self, now: SocketTime, tsn: Tsn) -> Option<Duration> {
-        if tsn > self.last_cumulative_tsn_ack && tsn < self.next_tsn() {
+        if tsn.greater_than(self.last_cumulative_tsn_ack) && tsn.less_than(self.next_tsn()) {
             let index = tsn.distance_to(self.last_cumulative_tsn_ack) - 1;
             let item = self.outstanding_data.get_mut(index as usize).unwrap();
             return item.get_rtt_from(now);
@@ -854,7 +899,7 @@ impl OutstandingData {
     /// Called when an outgoing stream reset is sent, marking the last assigned TSN as a breakpoint
     /// that a FORWARD-TSN shouldn't cross.
     pub fn begin_reset_streams(&mut self) {
-        self.stream_reset_breakpoint_tsns.insert(self.next_tsn());
+        self.stream_reset_breakpoint_tsns.insert(OrderedTsn(self.next_tsn()));
     }
 }
 

--- a/src/tx/retransmission_queue.rs
+++ b/src/tx/retransmission_queue.rs
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 use crate::EventSink;
 use crate::api::Options;
 use crate::api::SocketEvent;
@@ -33,6 +32,7 @@ use crate::tx::outstanding_data::ChunkState;
 use crate::tx::outstanding_data::OutstandingData;
 use crate::tx::send_queue::DataToSend;
 use crate::types::OutgoingMessageId;
+use crate::types::SerialNumber;
 use crate::types::Tsn;
 use std::cell::RefCell;
 use std::cmp::max;
@@ -169,7 +169,7 @@ impl RetransmissionQueue {
     fn is_sack_valid(&self, sack: &SackChunk) -> bool {
         // Important not to drop SACKs with identical TSN to that previously received, as the gap
         // ACK blocks or dup TSN fields may have changed.
-        if sack.cumulative_tsn_ack < self.outstanding_data.last_cumulative_acked_tsn() {
+        if sack.cumulative_tsn_ack.less_than(self.outstanding_data.last_cumulative_acked_tsn()) {
             // From <https://datatracker.ietf.org/doc/html/rfc9260#section-6.2.1-5.4.2.1.1>:
             //
             //   If Cumulative TSN Ack is less than the Cumulative TSN Ack Point, then drop the SACK
@@ -178,13 +178,14 @@ impl RetransmissionQueue {
             //   out-of-order SACK chunk.
             false
         } else {
-            sack.cumulative_tsn_ack <= self.outstanding_data.highest_outstanding_tsn()
+            sack.cumulative_tsn_ack
+                .less_than_or_equal(self.outstanding_data.highest_outstanding_tsn())
         }
     }
 
     fn maybe_exit_fast_recovery(&mut self, cumulative_tsn_ack: Tsn) {
         if let Some(fast_recovery_exit_tsn) = self.fast_recovery_exit_tsn {
-            if cumulative_tsn_ack >= fast_recovery_exit_tsn {
+            if cumulative_tsn_ack.greater_than_or_equal(fast_recovery_exit_tsn) {
                 self.fast_recovery_exit_tsn = None;
             }
         }
@@ -373,7 +374,7 @@ impl RetransmissionQueue {
             old_rwnd
         );
 
-        if sack.cumulative_tsn_ack > old_last_cumulative_tsn_ack {
+        if sack.cumulative_tsn_ack.greater_than(old_last_cumulative_tsn_ack) {
             // From <https://datatracker.ietf.org/doc/html/rfc9260#section-6.3.2-2.3.1>:
             //
             //   Whenever a SACK chunk is received that acknowledges the DATA chunk with the

--- a/src/types.rs
+++ b/src/types.rs
@@ -46,7 +46,7 @@ impl StreamKey {
     }
 }
 
-pub trait SerialNumber: Sized + Copy + Eq + Ord {
+pub trait SerialNumber: Sized + Copy + Eq {
     type DistanceType;
 
     /// Calculates the absolute distance `|self - other|` between two sequence numbers,
@@ -54,8 +54,25 @@ pub trait SerialNumber: Sized + Copy + Eq + Ord {
     fn distance_to(self, other: Self) -> Self::DistanceType;
 
     /// Returns true if this sequence number is strictly greater than `base`.
-    /// This corresponds to the strictly "greater than" half of the sequence space.
+    /// This corresponds to the strictly "greater than" half of the sequence space,
+    /// excluding equality and the exact half-space ambiguity point.
     fn greater_than(&self, base: Self) -> bool;
+
+    /// Returns true if this sequence number is strictly less than `other`
+    /// (i.e. `other` is strictly greater than `self`).
+    fn less_than(&self, other: Self) -> bool {
+        other.greater_than(*self)
+    }
+
+    /// Returns true if this sequence number is less than or equal to `other`.
+    fn less_than_or_equal(&self, other: Self) -> bool {
+        *self == other || other.greater_than(*self)
+    }
+
+    /// Returns true if this sequence number is greater than or equal to `other`.
+    fn greater_than_or_equal(&self, other: Self) -> bool {
+        *self == other || self.greater_than(other)
+    }
 }
 
 macro_rules! define_rfc1982_serial {
@@ -73,24 +90,6 @@ macro_rules! define_rfc1982_serial {
         impl std::fmt::Display for $name {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 write!(f, "{}", self.0)
-            }
-        }
-
-        impl std::cmp::PartialOrd for $name {
-            fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-                Some(self.cmp(other))
-            }
-        }
-
-        impl std::cmp::Ord for $name {
-            fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-                if self == other {
-                    std::cmp::Ordering::Equal
-                } else if other.greater_than(*self) {
-                    std::cmp::Ordering::Less
-                } else {
-                    std::cmp::Ordering::Greater
-                }
             }
         }
 
@@ -128,7 +127,7 @@ macro_rules! define_rfc1982_serial {
             type DistanceType = $int_type;
 
             fn distance_to(self, other: Self) -> $int_type {
-                if self > other {
+                if self.greater_than(other) {
                     self.0.wrapping_sub(other.0)
                 } else {
                     other.0.wrapping_sub(self.0)
@@ -188,26 +187,26 @@ mod tests {
     #[test]
     fn tsn_cmp() {
         assert!(Tsn(42) == Tsn(42));
-        assert!(Tsn(1) > Tsn(0));
-        assert!(Tsn(0) < Tsn(1));
-        assert!(Tsn(44) > Tsn(0));
-        assert!(Tsn(0) < Tsn(44));
-        assert!(Tsn(100) > Tsn(0));
-        assert!(Tsn(0) < Tsn(100));
-        assert!(Tsn(100) > Tsn(44));
-        assert!(Tsn(44) < Tsn(100));
-        assert!(Tsn(200) > Tsn(100));
-        assert!(Tsn(100) < Tsn(200));
-        assert!(Tsn(255) > Tsn(200));
-        assert!(Tsn(200) < Tsn(255));
-        assert!(Tsn(0) > Tsn(MAX_U32));
-        assert!(Tsn(MAX_U32) < Tsn(0));
-        assert!(Tsn(100) > Tsn(MAX_U32));
-        assert!(Tsn(MAX_U32) < Tsn(100));
-        assert!(Tsn(0) > Tsn(MAX_U32));
-        assert!(Tsn(MAX_U32) < Tsn(0));
-        assert!(Tsn(44) > Tsn(MAX_U32));
-        assert!(Tsn(MAX_U32) < Tsn(44));
+        assert!(Tsn(1).greater_than(Tsn(0)));
+        assert!(Tsn(0).less_than(Tsn(1)));
+        assert!(Tsn(44).greater_than(Tsn(0)));
+        assert!(Tsn(0).less_than(Tsn(44)));
+        assert!(Tsn(100).greater_than(Tsn(0)));
+        assert!(Tsn(0).less_than(Tsn(100)));
+        assert!(Tsn(100).greater_than(Tsn(44)));
+        assert!(Tsn(44).less_than(Tsn(100)));
+        assert!(Tsn(200).greater_than(Tsn(100)));
+        assert!(Tsn(100).less_than(Tsn(200)));
+        assert!(Tsn(255).greater_than(Tsn(200)));
+        assert!(Tsn(200).less_than(Tsn(255)));
+        assert!(Tsn(0).greater_than(Tsn(MAX_U32)));
+        assert!(Tsn(MAX_U32).less_than(Tsn(0)));
+        assert!(Tsn(100).greater_than(Tsn(MAX_U32)));
+        assert!(Tsn(MAX_U32).less_than(Tsn(100)));
+        assert!(Tsn(0).greater_than(Tsn(MAX_U32)));
+        assert!(Tsn(MAX_U32).less_than(Tsn(0)));
+        assert!(Tsn(44).greater_than(Tsn(MAX_U32)));
+        assert!(Tsn(MAX_U32).less_than(Tsn(44)));
     }
 
     #[test]
@@ -292,26 +291,26 @@ mod tests {
     #[test]
     fn ssn_cmp() {
         assert!(Ssn(42) == Ssn(42));
-        assert!(Ssn(1) > Ssn(0));
-        assert!(Ssn(0) < Ssn(1));
-        assert!(Ssn(44) > Ssn(0));
-        assert!(Ssn(0) < Ssn(44));
-        assert!(Ssn(100) > Ssn(0));
-        assert!(Ssn(0) < Ssn(100));
-        assert!(Ssn(100) > Ssn(44));
-        assert!(Ssn(44) < Ssn(100));
-        assert!(Ssn(200) > Ssn(100));
-        assert!(Ssn(100) < Ssn(200));
-        assert!(Ssn(255) > Ssn(200));
-        assert!(Ssn(200) < Ssn(255));
-        assert!(Ssn(0) > Ssn(MAX_U16));
-        assert!(Ssn(MAX_U16) < Ssn(0));
-        assert!(Ssn(100) > Ssn(MAX_U16));
-        assert!(Ssn(MAX_U16) < Ssn(100));
-        assert!(Ssn(0) > Ssn(MAX_U16));
-        assert!(Ssn(MAX_U16) < Ssn(0));
-        assert!(Ssn(44) > Ssn(MAX_U16));
-        assert!(Ssn(MAX_U16) < Ssn(44));
+        assert!(Ssn(1).greater_than(Ssn(0)));
+        assert!(Ssn(0).less_than(Ssn(1)));
+        assert!(Ssn(44).greater_than(Ssn(0)));
+        assert!(Ssn(0).less_than(Ssn(44)));
+        assert!(Ssn(100).greater_than(Ssn(0)));
+        assert!(Ssn(0).less_than(Ssn(100)));
+        assert!(Ssn(100).greater_than(Ssn(44)));
+        assert!(Ssn(44).less_than(Ssn(100)));
+        assert!(Ssn(200).greater_than(Ssn(100)));
+        assert!(Ssn(100).less_than(Ssn(200)));
+        assert!(Ssn(255).greater_than(Ssn(200)));
+        assert!(Ssn(200).less_than(Ssn(255)));
+        assert!(Ssn(0).greater_than(Ssn(MAX_U16)));
+        assert!(Ssn(MAX_U16).less_than(Ssn(0)));
+        assert!(Ssn(100).greater_than(Ssn(MAX_U16)));
+        assert!(Ssn(MAX_U16).less_than(Ssn(100)));
+        assert!(Ssn(0).greater_than(Ssn(MAX_U16)));
+        assert!(Ssn(MAX_U16).less_than(Ssn(0)));
+        assert!(Ssn(44).greater_than(Ssn(MAX_U16)));
+        assert!(Ssn(MAX_U16).less_than(Ssn(44)));
     }
 
     #[test]
@@ -350,52 +349,52 @@ mod tests {
     #[test]
     fn mid_cmp() {
         assert!(Mid(42) == Mid(42));
-        assert!(Mid(1) > Mid(0));
-        assert!(Mid(0) < Mid(1));
-        assert!(Mid(44) > Mid(0));
-        assert!(Mid(0) < Mid(44));
-        assert!(Mid(100) > Mid(0));
-        assert!(Mid(0) < Mid(100));
-        assert!(Mid(100) > Mid(44));
-        assert!(Mid(44) < Mid(100));
-        assert!(Mid(200) > Mid(100));
-        assert!(Mid(100) < Mid(200));
-        assert!(Mid(255) > Mid(200));
-        assert!(Mid(200) < Mid(255));
-        assert!(Mid(0) > Mid(MAX_U32));
-        assert!(Mid(MAX_U32) < Mid(0));
-        assert!(Mid(100) > Mid(MAX_U32));
-        assert!(Mid(MAX_U32) < Mid(100));
-        assert!(Mid(0) > Mid(MAX_U32));
-        assert!(Mid(MAX_U32) < Mid(0));
-        assert!(Mid(44) > Mid(MAX_U32));
-        assert!(Mid(MAX_U32) < Mid(44));
+        assert!(Mid(1).greater_than(Mid(0)));
+        assert!(Mid(0).less_than(Mid(1)));
+        assert!(Mid(44).greater_than(Mid(0)));
+        assert!(Mid(0).less_than(Mid(44)));
+        assert!(Mid(100).greater_than(Mid(0)));
+        assert!(Mid(0).less_than(Mid(100)));
+        assert!(Mid(100).greater_than(Mid(44)));
+        assert!(Mid(44).less_than(Mid(100)));
+        assert!(Mid(200).greater_than(Mid(100)));
+        assert!(Mid(100).less_than(Mid(200)));
+        assert!(Mid(255).greater_than(Mid(200)));
+        assert!(Mid(200).less_than(Mid(255)));
+        assert!(Mid(0).greater_than(Mid(MAX_U32)));
+        assert!(Mid(MAX_U32).less_than(Mid(0)));
+        assert!(Mid(100).greater_than(Mid(MAX_U32)));
+        assert!(Mid(MAX_U32).less_than(Mid(100)));
+        assert!(Mid(0).greater_than(Mid(MAX_U32)));
+        assert!(Mid(MAX_U32).less_than(Mid(0)));
+        assert!(Mid(44).greater_than(Mid(MAX_U32)));
+        assert!(Mid(MAX_U32).less_than(Mid(44)));
     }
 
     #[test]
     fn fsn_cmp() {
         assert!(Fsn(42) == Fsn(42));
-        assert!(Fsn(1) > Fsn(0));
-        assert!(Fsn(0) < Fsn(1));
-        assert!(Fsn(1) > Fsn(0));
-        assert!(Fsn(0) < Fsn(1));
-        assert!(Fsn(44) > Fsn(0));
-        assert!(Fsn(0) < Fsn(44));
-        assert!(Fsn(100) > Fsn(0));
-        assert!(Fsn(0) < Fsn(100));
-        assert!(Fsn(100) > Fsn(44));
-        assert!(Fsn(44) < Fsn(100));
-        assert!(Fsn(200) > Fsn(100));
-        assert!(Fsn(100) < Fsn(200));
-        assert!(Fsn(255) > Fsn(200));
-        assert!(Fsn(200) < Fsn(255));
-        assert!(Fsn(0) > Fsn(MAX_U32));
-        assert!(Fsn(MAX_U32) < Fsn(0));
-        assert!(Fsn(100) > Fsn(MAX_U32));
-        assert!(Fsn(MAX_U32) < Fsn(100));
-        assert!(Fsn(0) > Fsn(MAX_U32));
-        assert!(Fsn(MAX_U32) < Fsn(0));
-        assert!(Fsn(44) > Fsn(MAX_U32));
-        assert!(Fsn(MAX_U32) < Fsn(44));
+        assert!(Fsn(1).greater_than(Fsn(0)));
+        assert!(Fsn(0).less_than(Fsn(1)));
+        assert!(Fsn(1).greater_than(Fsn(0)));
+        assert!(Fsn(0).less_than(Fsn(1)));
+        assert!(Fsn(44).greater_than(Fsn(0)));
+        assert!(Fsn(0).less_than(Fsn(44)));
+        assert!(Fsn(100).greater_than(Fsn(0)));
+        assert!(Fsn(0).less_than(Fsn(100)));
+        assert!(Fsn(100).greater_than(Fsn(44)));
+        assert!(Fsn(44).less_than(Fsn(100)));
+        assert!(Fsn(200).greater_than(Fsn(100)));
+        assert!(Fsn(100).less_than(Fsn(200)));
+        assert!(Fsn(255).greater_than(Fsn(200)));
+        assert!(Fsn(200).less_than(Fsn(255)));
+        assert!(Fsn(0).greater_than(Fsn(MAX_U32)));
+        assert!(Fsn(MAX_U32).less_than(Fsn(0)));
+        assert!(Fsn(100).greater_than(Fsn(MAX_U32)));
+        assert!(Fsn(MAX_U32).less_than(Fsn(100)));
+        assert!(Fsn(0).greater_than(Fsn(MAX_U32)));
+        assert!(Fsn(MAX_U32).less_than(Fsn(0)));
+        assert!(Fsn(44).greater_than(Fsn(MAX_U32)));
+        assert!(Fsn(MAX_U32).less_than(Fsn(44)));
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use crate::api::StreamId;
-use std::cmp::Ordering;
 use std::fmt;
 
 /// Ordered/Unordered stream identifiers.
@@ -47,258 +46,113 @@ impl StreamKey {
     }
 }
 
-/// See <https://datatracker.ietf.org/doc/html/rfc1982#section-3.2>.
-fn cmp_rfc1982_u32(a: u32, b: u32) -> Ordering {
-    if a == b {
-        Ordering::Equal
-    } else if (a < b && (b - a) < (1 << 31)) || (a > b && (a - b) > (1 << 31)) {
-        Ordering::Less
-    } else {
-        Ordering::Greater
-    }
+pub trait SerialNumber: Sized + Copy + Eq + Ord {
+    type DistanceType;
+
+    /// Calculates the absolute distance `|self - other|` between two sequence numbers,
+    /// properly accounting for sequence space wrapping.
+    fn distance_to(self, other: Self) -> Self::DistanceType;
+
+    /// Returns true if this sequence number is strictly greater than `base`.
+    /// This corresponds to the strictly "greater than" half of the sequence space.
+    fn greater_than(&self, base: Self) -> bool;
 }
 
-fn cmp_rfc1982_u16(a: u16, b: u16) -> Ordering {
-    if a == b {
-        Ordering::Equal
-    } else if (a < b && (b - a) < (1 << 15)) || (a > b && (a - b) > (1 << 15)) {
-        Ordering::Less
-    } else {
-        Ordering::Greater
-    }
+macro_rules! define_rfc1982_serial {
+    ($name:ident, $int_type:ident, $half_space:expr, $doc:expr) => {
+        #[doc = $doc]
+        #[derive(Clone, Copy, Eq, Hash, PartialEq)]
+        pub struct $name(pub $int_type);
+
+        impl std::fmt::Debug for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                std::fmt::Display::fmt(self, f)
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{}", self.0)
+            }
+        }
+
+        impl std::cmp::PartialOrd for $name {
+            fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+                Some(self.cmp(other))
+            }
+        }
+
+        impl std::cmp::Ord for $name {
+            fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+                if self == other {
+                    std::cmp::Ordering::Equal
+                } else if other.greater_than(*self) {
+                    std::cmp::Ordering::Less
+                } else {
+                    std::cmp::Ordering::Greater
+                }
+            }
+        }
+
+        impl std::ops::Add<$int_type> for $name {
+            type Output = $name;
+
+            #[inline]
+            fn add(self, rhs: $int_type) -> $name {
+                $name(self.0.wrapping_add(rhs))
+            }
+        }
+
+        impl std::ops::Sub<$int_type> for $name {
+            type Output = $name;
+
+            #[inline]
+            fn sub(self, rhs: $int_type) -> $name {
+                $name(self.0.wrapping_sub(rhs))
+            }
+        }
+
+        impl std::ops::AddAssign<$int_type> for $name {
+            fn add_assign(&mut self, rhs: $int_type) {
+                self.0 = self.0.wrapping_add(rhs);
+            }
+        }
+
+        impl std::ops::SubAssign<$int_type> for $name {
+            fn sub_assign(&mut self, rhs: $int_type) {
+                self.0 = self.0.wrapping_sub(rhs);
+            }
+        }
+
+        impl SerialNumber for $name {
+            type DistanceType = $int_type;
+
+            fn distance_to(self, other: Self) -> $int_type {
+                if self > other {
+                    self.0.wrapping_sub(other.0)
+                } else {
+                    other.0.wrapping_sub(self.0)
+                }
+            }
+
+            fn greater_than(&self, base: Self) -> bool {
+                let diff = self.0.wrapping_sub(base.0);
+                diff > 0 && diff < $half_space
+            }
+        }
+
+        impl $name {
+            pub fn add_to(self, other: $int_type) -> Self {
+                $name(self.0.wrapping_add(other))
+            }
+        }
+    };
 }
 
-/// Stream Sequence Number (SSN)
-#[derive(Clone, Copy, Eq, Hash, PartialEq)]
-pub struct Ssn(pub u16);
-
-impl fmt::Debug for Ssn {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(self, f)
-    }
-}
-
-impl fmt::Display for Ssn {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl std::cmp::PartialOrd for Ssn {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl std::cmp::Ord for Ssn {
-    fn cmp(&self, other: &Self) -> Ordering {
-        // From <https://datatracker.ietf.org/doc/html/rfc9260#section-1.6>:
-        //
-        //   Any arithmetic done on Stream Sequence Numbers SHOULD use Serial Number Arithmetic, as
-        //   defined in [RFC1982] [...]
-        cmp_rfc1982_u16(self.0, other.0)
-    }
-}
-
-impl std::ops::Add<u16> for Ssn {
-    type Output = Ssn;
-
-    #[inline]
-    fn add(self, rhs: u16) -> Ssn {
-        Ssn(self.0.wrapping_add(rhs))
-    }
-}
-
-impl std::ops::Sub<u16> for Ssn {
-    type Output = Ssn;
-
-    #[inline]
-    fn sub(self, rhs: u16) -> Ssn {
-        Ssn(self.0.wrapping_sub(rhs))
-    }
-}
-
-impl std::ops::AddAssign<u16> for Ssn {
-    fn add_assign(&mut self, rhs: u16) {
-        self.0 = self.0.wrapping_add(rhs);
-    }
-}
-
-impl std::ops::SubAssign<u16> for Ssn {
-    fn sub_assign(&mut self, rhs: u16) {
-        self.0 = self.0.wrapping_sub(rhs);
-    }
-}
-
-/// Message Identifier (MID)
-#[derive(Clone, Copy, Eq, Hash, PartialEq)]
-pub struct Mid(pub u32);
-
-impl fmt::Debug for Mid {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(self, f)
-    }
-}
-
-impl fmt::Display for Mid {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl std::cmp::PartialOrd for Mid {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl std::cmp::Ord for Mid {
-    fn cmp(&self, other: &Self) -> Ordering {
-        // From <https://datatracker.ietf.org/doc/html/rfc8260#section-2.1>:
-        //
-        //   Please note that the serial number arithmetic defined in [RFC1982] [...] applies.
-        cmp_rfc1982_u32(self.0, other.0)
-    }
-}
-
-impl std::ops::AddAssign<u32> for Mid {
-    fn add_assign(&mut self, rhs: u32) {
-        self.0 = self.0.wrapping_add(rhs);
-    }
-}
-
-impl std::ops::Add<u32> for Mid {
-    type Output = Mid;
-
-    #[inline]
-    fn add(self, rhs: u32) -> Mid {
-        Mid(self.0.wrapping_add(rhs))
-    }
-}
-
-/// Fragment Sequence Number (FSN)
-#[derive(Clone, Copy, Eq, Hash, PartialEq)]
-pub struct Fsn(pub u32);
-
-impl fmt::Debug for Fsn {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(self, f)
-    }
-}
-
-impl fmt::Display for Fsn {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl std::cmp::PartialOrd for Fsn {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl std::cmp::Ord for Fsn {
-    fn cmp(&self, other: &Self) -> Ordering {
-        // From <https://datatracker.ietf.org/doc/html/rfc8260#section-2.1>:
-        //
-        //   For the FSN, the serial number arithmetic defined in [RFC1982] applies [...]
-        cmp_rfc1982_u32(self.0, other.0)
-    }
-}
-
-impl std::ops::Add<u32> for Fsn {
-    type Output = Fsn;
-
-    #[inline]
-    fn add(self, rhs: u32) -> Fsn {
-        Fsn(self.0.wrapping_add(rhs))
-    }
-}
-
-impl std::ops::AddAssign<u32> for Fsn {
-    fn add_assign(&mut self, rhs: u32) {
-        self.0 = self.0.wrapping_add(rhs);
-    }
-}
-
-impl Fsn {
-    pub fn distance_to(self, other: Fsn) -> u32 {
-        if self > other { self.0.wrapping_sub(other.0) } else { other.0.wrapping_sub(self.0) }
-    }
-}
-
-/// Transmission Sequence Number (TSN)
-#[derive(Clone, Copy, Eq, Hash, PartialEq)]
-pub struct Tsn(pub u32);
-
-impl fmt::Debug for Tsn {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(self, f)
-    }
-}
-
-impl fmt::Display for Tsn {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl std::cmp::PartialOrd for Tsn {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl std::cmp::Ord for Tsn {
-    fn cmp(&self, other: &Self) -> Ordering {
-        // From <https://datatracker.ietf.org/doc/html/rfc9260#section-1.6-2>:
-        //
-        //   Comparisons and arithmetic on TSNs in this document SHOULD use Serial Number
-        //   Arithmetic, as defined in [RFC1982] [...]
-        cmp_rfc1982_u32(self.0, other.0)
-    }
-}
-
-impl std::ops::Add<u32> for Tsn {
-    type Output = Tsn;
-
-    #[inline]
-    fn add(self, rhs: u32) -> Tsn {
-        Tsn(self.0.wrapping_add(rhs))
-    }
-}
-
-impl std::ops::Sub<u32> for Tsn {
-    type Output = Tsn;
-
-    #[inline]
-    fn sub(self, rhs: u32) -> Tsn {
-        Tsn(self.0.wrapping_sub(rhs))
-    }
-}
-
-impl std::ops::AddAssign<u32> for Tsn {
-    fn add_assign(&mut self, rhs: u32) {
-        self.0 = self.0.wrapping_add(rhs);
-    }
-}
-
-impl std::ops::SubAssign<u32> for Tsn {
-    fn sub_assign(&mut self, rhs: u32) {
-        self.0 = self.0.wrapping_sub(rhs);
-    }
-}
-
-impl Tsn {
-    pub fn add_to(self, other: u32) -> Tsn {
-        Tsn(self.0.wrapping_add(other))
-    }
-
-    pub fn distance_to(self, other: Tsn) -> u32 {
-        if self > other { self.0.wrapping_sub(other.0) } else { other.0.wrapping_sub(self.0) }
-    }
-}
+define_rfc1982_serial!(Ssn, u16, 1 << 15, "Stream Sequence Number (SSN)");
+define_rfc1982_serial!(Mid, u32, 1 << 31, "Message Identifier (MID)");
+define_rfc1982_serial!(Fsn, u32, 1 << 31, "Fragment Sequence Number (FSN)");
+define_rfc1982_serial!(Tsn, u32, 1 << 31, "Transmission Sequence Number (TSN)");
 
 /// An ID for every outgoing message, to correlate outgoing data chunks with the message it was
 /// carved from. It can only be compared by equality - there is no defined ordering.


### PR DESCRIPTION
Two commits. First one refactoring, to simplify how RFC1982 types are defined - introducing a helper to safely verify if another value of the same type is strictly and safely "greater", but not too much into the future, to cause wraparound. And using a macro to define them, because these types had a lot of duplication, and duplication risk having implementations that diverge. I'm usually not a fan of macros, but this was an exception.

The second commit fixes a vulnerability where an attacker could cause a panic by sending unordered interleaved stream fragments with Message Identifiers (MIDs) chosen exactly 2^31 apart.

The unordered stream reassembler uses IntervalList, which relies on slice::partition_point. This standard library method requires a strict linear total order to perform binary search. RFC1982 sequence spaces are circular, meaning they violate total ordering at their maximum distance (e.g. A < B < C < A). When chunks arrive with MIDs exactly at this maximum boundary, partition_point fails its invariants and panics.

Ordered streams are immune to this panic because they drop chunks that fall outside a strictly validated forward half-space window (via  next_mid and is_valid_successor). This constrains their queued chunks to  a narrow slice of the circle where the math never wraps around, allowing partition_point to sort them safely.

Unordered streams, however, have no such delivery window and accept chunks from anywhere on the sequence circle. But for unordered chunks,  the MIDs have no real ordering; The MID is used exclusively as a correlation ID to group fragments of the same message together. The relative order of different unordered MIDs is completely irrelevant.