### PR TITLE
Validate nonce before stopping heartbeat timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to
  - Refactored ReassemblyQueue byte tracking into smaller parts, fixing integer
    underflows and double-counting bugs.
  - Discard FORWARD-TSN with invalid TSN.
+ - Stop heartbeat timeout only after validating nonce in HEARTBEAT-ACK.
 
 ## 0.1.13 - 2026-05-20
 

--- a/src/socket/heartbeat.rs
+++ b/src/socket/heartbeat.rs
@@ -46,7 +46,6 @@ pub(crate) fn handle_heartbeat_req(
 }
 
 pub(crate) fn handle_heartbeat_ack(ctx: &mut Context, now: SocketTime, chunk: HeartbeatAckChunk) {
-    ctx.heartbeat_timeout.stop();
     match chunk.parameters.iter().find_map(|p| match p {
         Parameter::HeartbeatInfo(HeartbeatInfoParameter { info }) => Some(info),
         _ => None,
@@ -54,6 +53,7 @@ pub(crate) fn handle_heartbeat_ack(ctx: &mut Context, now: SocketTime, chunk: He
         Some(info) if info.len() == 4 => {
             let counter = read_u32_be!(&info);
             if counter == ctx.heartbeat_counter {
+                ctx.heartbeat_timeout.stop();
                 let _rtt = now - ctx.heartbeat_sent_time;
                 // From <https://datatracker.ietf.org/doc/html/rfc9260#section-8.1>:
                 //

--- a/src/socket/socket_tests.rs
+++ b/src/socket/socket_tests.rs
@@ -1076,6 +1076,49 @@ mod tests {
     }
 
     #[test]
+    fn close_connection_if_heartbeat_ack_is_invalid() {
+        let mut options = default_options();
+        options.heartbeat_interval = Duration::from_secs(30);
+        options.max_retransmissions = Some(0);
+        let mut now = SocketTime::zero();
+        let mut socket_a = Socket::new("A", &options);
+        let mut socket_z = Socket::new("Z", &options);
+        connect_sockets(&mut socket_a, &mut socket_z);
+
+        now = now + options.heartbeat_interval;
+        socket_a.advance_time(now);
+        let hb_packet = expect_sent_packet!(socket_a.poll_event());
+        let hb_packet = SctpPacket::from_bytes(&hb_packet, &options).unwrap();
+        assert!(matches!(hb_packet.chunks[0], Chunk::HeartbeatRequest(_)));
+
+        // Send an invalid HeartbeatAckChunk with wrong nonce.
+        let invalid_ack_packet = SctpPacketBuilder::new(
+            socket_a.verification_tag(),
+            options.local_port,
+            options.remote_port,
+            options.mtu,
+        )
+        .add(&Chunk::HeartbeatAck(HeartbeatAckChunk {
+            parameters: vec![Parameter::HeartbeatInfo(HeartbeatInfoParameter {
+                info: vec![0xFF, 0xFF, 0xFF, 0xFF],
+            })],
+        }))
+        .build();
+        socket_a.handle_input(&invalid_ack_packet);
+
+        // Letting the heartbeat expire, since the invalid ack should not have stopped the timeout.
+        now = now + options.rto_initial;
+        socket_a.advance_time(now);
+
+        let abort_packet = expect_sent_packet!(socket_a.poll_event());
+        let abort_packet = SctpPacket::from_bytes(&abort_packet, &options).unwrap();
+        assert!(matches!(abort_packet.chunks[0], Chunk::Abort(_)));
+
+        assert_eq!(expect_on_aborted!(socket_a.poll_event()), ErrorKind::TooManyRetries);
+        expect_no_event!(socket_a.poll_event());
+    }
+
+    #[test]
     fn close_connection_after_second_lost_heartbeat() {
         let mut options = default_options();
         options.heartbeat_interval = Duration::from_secs(30);


### PR DESCRIPTION
In handle_heartbeat_ack, the heartbeat timeout was unconditionally stopped before verifying that the received HEARTBEAT-ACK chunk contained the correct nonce.

This allowed an attacker or faulty peer to send invalid HEARTBEAT-ACK chunks, cancelling the liveness timer and preventing the connection from properly aborting on failure.

The timeout is now stopped only after validating the returned nonce.