### PR TITLE
Avoid exceeding MTU when echoing/reflecting packets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to
    underflows and double-counting bugs.
  - Discard FORWARD-TSN with invalid TSN.
  - Stop heartbeat timeout only after validating nonce in HEARTBEAT-ACK.
+ - Dropping/truncating oversized Unrecognized or HEARTBEAT chunks.
 
 ## 0.1.13 - 2026-05-20
 

--- a/src/packet/error_chunk.rs
+++ b/src/packet/error_chunk.rs
@@ -24,6 +24,7 @@ use crate::packet::parameter::parameters_serialized_size;
 use std::fmt;
 
 pub(crate) const CHUNK_TYPE: u8 = 9;
+pub(crate) const HEADER_SIZE: usize = 4;
 
 /// Operation Error (ERROR) chunk
 ///

--- a/src/packet/heartbeat_ack_chunk.rs
+++ b/src/packet/heartbeat_ack_chunk.rs
@@ -24,6 +24,7 @@ use crate::packet::parameter::parameters_serialized_size;
 use std::fmt;
 
 pub(crate) const CHUNK_TYPE: u8 = 5;
+pub(crate) const HEADER_SIZE: usize = 4;
 
 /// Heartbeat Acknowledgement (HEARTBEAT ACK) chunk
 ///

--- a/src/packet/sctp_packet.rs
+++ b/src/packet/sctp_packet.rs
@@ -178,12 +178,22 @@ impl SctpPacketBuilder {
 
         let chunk_offset = self.data.len();
         let chunk_size = chunk.as_serializable().serialized_size();
-        self.data.resize(round_up_to_4!(self.data.len() + chunk_size), 0);
+        let new_len = round_up_to_4!(self.data.len() + chunk_size);
+        debug_assert!(
+            new_len <= self.max_packet_size,
+            "packet too large: {} > {}",
+            new_len,
+            self.max_packet_size
+        );
+        if new_len > self.max_packet_size {
+            return self;
+        }
+
+        self.data.resize(new_len, 0);
         chunk
             .as_serializable()
             .serialize_to(&mut self.data[chunk_offset..chunk_offset + chunk_size]);
         debug_assert!(is_divisible_by_4!(self.data.len()));
-        debug_assert!(self.data.len() <= self.max_packet_size);
         self
     }
 

--- a/src/socket/heartbeat.rs
+++ b/src/socket/heartbeat.rs
@@ -15,7 +15,9 @@
 use crate::api::ErrorKind;
 use crate::api::SocketEvent;
 use crate::api::SocketTime;
+use crate::math::round_down_to_4;
 use crate::packet::chunk::Chunk;
+use crate::packet::heartbeat_ack_chunk;
 use crate::packet::heartbeat_ack_chunk::HeartbeatAckChunk;
 use crate::packet::heartbeat_info_parameter::HeartbeatInfoParameter;
 use crate::packet::heartbeat_request_chunk::HeartbeatRequestChunk;
@@ -36,12 +38,21 @@ pub(crate) fn handle_heartbeat_req(
     //   chunk that contains the Heartbeat Information TLV, together with any other received
     //   TLVs, copied unchanged from the received HEARTBEAT chunk.
     if let Some(tcb) = state.tcb_mut() {
-        ctx.events.borrow_mut().add(SocketEvent::SendPacket(
-            tcb.new_packet()
-                .add(&Chunk::HeartbeatAck(HeartbeatAckChunk { parameters: chunk.parameters }))
-                .build(),
-        ));
-        ctx.tx_packets_count += 1;
+        let mut packet = tcb.new_packet();
+
+        let max_params_len = round_down_to_4!(
+            packet.bytes_remaining().saturating_sub(heartbeat_ack_chunk::HEADER_SIZE)
+        );
+        let params_size = crate::packet::parameter::parameters_serialized_size(&chunk.parameters);
+
+        if params_size <= max_params_len {
+            ctx.events.borrow_mut().add(SocketEvent::SendPacket(
+                packet
+                    .add(&Chunk::HeartbeatAck(HeartbeatAckChunk { parameters: chunk.parameters }))
+                    .build(),
+            ));
+            ctx.tx_packets_count += 1;
+        }
     }
 }
 

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -34,16 +34,19 @@ use crate::api::handover::HandoverSocketState;
 use crate::api::handover::SocketHandoverState;
 use crate::events::Events;
 use crate::logging::log_packet;
+use crate::math::round_down_to_4;
 use crate::packet::SerializableTlv;
 use crate::packet::abort_chunk::AbortChunk;
 use crate::packet::chunk::Chunk;
 use crate::packet::data_chunk;
 use crate::packet::data_chunk::DataChunk;
 use crate::packet::error_causes::ErrorCause;
+use crate::packet::error_chunk;
 use crate::packet::error_chunk::ErrorChunk;
 use crate::packet::forward_tsn_chunk::ForwardTsnChunk;
 use crate::packet::idata_chunk::IDataChunk;
 use crate::packet::iforward_tsn_chunk::IForwardTsnChunk;
+use crate::packet::parameter::PARAMETER_HEADER_SIZE;
 use crate::packet::protocol_violation_error_cause::ProtocolViolationErrorCause;
 use crate::packet::sctp_packet;
 use crate::packet::sctp_packet::SctpPacket;
@@ -435,10 +438,19 @@ impl Socket {
             //   [...] report the unrecognized chunk in an ERROR chunk using the 'Unrecognized Chunk
             //   Type' error cause.
             if let Some(tcb) = self.state.tcb() {
+                let mut packet = tcb.new_packet();
+                // To avoid exceeding MTU, limit what is echoed back.
+                const OVERHEAD: usize = error_chunk::HEADER_SIZE + PARAMETER_HEADER_SIZE;
+                let max_len = round_down_to_4!(packet.bytes_remaining().saturating_sub(OVERHEAD));
+
                 let mut serialized = vec![0; chunk.serialized_size()];
                 chunk.serialize_to(&mut serialized);
+                if serialized.len() > max_len {
+                    serialized.truncate(max_len);
+                }
+
                 self.ctx.events.borrow_mut().add(SocketEvent::SendPacket(
-                    tcb.new_packet()
+                    packet
                         .add(&Chunk::Error(ErrorChunk {
                             error_causes: vec![ErrorCause::UnrecognizedChunk(
                                 UnrecognizedChunkErrorCause { chunk: serialized },

--- a/src/socket/socket_tests.rs
+++ b/src/socket/socket_tests.rs
@@ -980,6 +980,32 @@ mod tests {
     }
 
     #[test]
+    fn oversized_heartbeat_request_is_dropped() {
+        let options = default_options();
+        let mut socket_a = Socket::new("A", &options);
+        let mut socket_z = Socket::new("Z", &options);
+        connect_sockets(&mut socket_a, &mut socket_z);
+
+        let packet = SctpPacketBuilder::new(
+            socket_a.verification_tag(),
+            options.local_port,
+            options.remote_port,
+            65535,
+        )
+        .add(&Chunk::HeartbeatRequest(HeartbeatRequestChunk {
+            parameters: vec![Parameter::HeartbeatInfo(HeartbeatInfoParameter {
+                info: vec![0u8; 2000],
+            })],
+        }))
+        .build();
+        socket_a.handle_input(&packet);
+
+        // The heartbeat parameters are too large to fit in an MTU-sized response.
+        // It should be completely dropped.
+        assert!(socket_a.poll_event().is_none());
+    }
+
+    #[test]
     fn expect_heartbeat_to_be_sent() {
         let mut options = default_options();
         options.heartbeat_interval = Duration::from_secs(30);
@@ -1937,6 +1963,39 @@ mod tests {
         socket_a.handle_input(&packet);
 
         assert_eq!(expect_on_error!(socket_a.poll_event()), ErrorKind::PeerReported);
+    }
+
+    #[test]
+    fn unrecognized_chunk_echoing_is_capped_to_mtu() {
+        let options = default_options();
+        let mut socket_a = Socket::new("A", &options);
+        let mut socket_z = Socket::new("Z", &options);
+        connect_sockets(&mut socket_a, &mut socket_z);
+
+        let packet = SctpPacketBuilder::new(
+            socket_a.verification_tag(),
+            options.local_port,
+            options.remote_port,
+            65535,
+        )
+        .add(&Chunk::Unknown(UnknownChunk { typ: 0x49, flags: 0, value: vec![0u8; 2000] }))
+        .build();
+        socket_a.handle_input(&packet);
+
+        assert_eq!(expect_on_error!(socket_a.poll_event()), ErrorKind::ParseFailed);
+
+        let out_bytes = expect_sent_packet!(socket_a.poll_event());
+        assert!(out_bytes.len() <= options.mtu);
+        let packet = SctpPacket::from_bytes(&out_bytes, &options).unwrap();
+
+        assert_eq!(packet.chunks.len(), 1);
+        let Chunk::Error(err) = &packet.chunks[0] else { panic!() };
+        assert_eq!(err.error_causes.len(), 1);
+        let ErrorCause::UnrecognizedChunk(unrec) = &err.error_causes[0] else { panic!() };
+
+        // Verify that the error chunk contains a truncated copy of the unrecognized chunk.
+        assert!(unrec.chunk.len() > 100);
+        assert!(unrec.chunk.len() < 2000);
     }
 
     #[test]


### PR DESCRIPTION
There are a few cases where the socket will echo back what the peer is sending. If for some reason they are able to send a very large message to us, that exceeds the configured MTU (note: configured and actual can differ), then we can't send that message to them - we can't exceed the MTU.

Heartbeats are supposed to be small, and if they are extremely large, it's probably someone doing something fishy. We can't truncate it, because it wouldn't be understood by the sender, so just drop it if it's that large.

When we receive unrecognized chunks, we echo back the chunk wrapped in an ERROR chunk. But that's just for them to be able to inspect what we didn't support. In this case, we're truncating it.