### PR TITLE
Limit the effect of state cookie tampering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to
  - Added Verification Tag validation on incoming packets as per RFC 9260 Section 8.5.
  - Validate incoming DATA/IDATA/FORWARD-TSN/I-FORWARD-TSN chunk types match negotiated message interleaving capability.
  - Validate incoming FORWARD-TSN/I-FORWARD-TSN to match negotiated partial reliability capability.
+ - Added prevention of state cookie forging and capability bypass.
 
 ### Fixed
 

--- a/src/socket/capabilities.rs
+++ b/src/socket/capabilities.rs
@@ -12,9 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::api::Options;
+use crate::api::ZERO_CHECKSUM_ALTERNATE_ERROR_DETECTION_METHOD_NONE;
+use crate::api::ZeroChecksumAlternateErrorDetectionMethod;
+use crate::packet::forward_tsn_chunk;
+use crate::packet::idata_chunk;
+use crate::packet::parameter::Parameter;
+use crate::packet::re_config_chunk;
+use crate::packet::supported_extensions_parameter::SupportedExtensionsParameter;
+use crate::packet::zero_checksum_acceptable_parameter::ZeroChecksumAcceptableParameter;
+use std::collections::HashSet;
+
 /// Indicates what the association supports, meaning that both parties support it and that feature
 /// can be used.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy)]
 pub struct Capabilities {
     /// RFC 3758 Partial Reliability Extension
     pub partial_reliability: bool,
@@ -25,12 +36,113 @@ pub struct Capabilities {
     /// RFC 6525 Stream Reconfiguration
     pub reconfig: bool,
 
-    /// RFC 9653 Zero Checksum
-    pub zero_checksum: bool,
+    /// RFC 9653 Zero Checksum Alternate Error Detection Method
+    pub zero_checksum_method: ZeroChecksumAlternateErrorDetectionMethod,
 
     /// Negotiated maximum incoming stream count.
     pub negotiated_maximum_incoming_streams: u16,
 
     /// Negotiated maximum outgoing stream count.
     pub negotiated_maximum_outgoing_streams: u16,
+}
+
+impl Default for Capabilities {
+    fn default() -> Self {
+        Self {
+            partial_reliability: false,
+            message_interleaving: false,
+            reconfig: false,
+            zero_checksum_method: ZERO_CHECKSUM_ALTERNATE_ERROR_DETECTION_METHOD_NONE,
+            negotiated_maximum_incoming_streams: 0,
+            negotiated_maximum_outgoing_streams: 0,
+        }
+    }
+}
+
+impl Capabilities {
+    /// Extracts capabilities from a list of parameters received from the peer.
+    ///
+    /// This parses the parameters (typically from an INIT or INIT ACK chunk)
+    /// to determine what features the peer supports and what limits it imposes.
+    pub fn from_parameters(
+        nbr_outbound_streams: u16,
+        nbr_inbound_streams: u16,
+        parameters: &[Parameter],
+    ) -> Self {
+        let supported: HashSet<u8> = parameters
+            .iter()
+            .find_map(|e| match e {
+                Parameter::SupportedExtensions(SupportedExtensionsParameter { chunk_types }) => {
+                    Some(chunk_types)
+                }
+                _ => None,
+            })
+            .unwrap_or(&vec![])
+            .iter()
+            .cloned()
+            .collect();
+
+        let partial_reliability =
+            parameters.iter().any(|e| matches!(e, Parameter::ForwardTsnSupported(_)))
+                || supported.contains(&forward_tsn_chunk::CHUNK_TYPE);
+
+        let message_interleaving = supported.contains(&idata_chunk::CHUNK_TYPE);
+
+        let reconfig = supported.contains(&re_config_chunk::CHUNK_TYPE);
+
+        let zero_checksum_method = *parameters
+            .iter()
+            .find_map(|e| match e {
+                Parameter::ZeroChecksumAcceptable(ZeroChecksumAcceptableParameter { method }) => {
+                    Some(method)
+                }
+                _ => None,
+            })
+            .unwrap_or(&ZERO_CHECKSUM_ALTERNATE_ERROR_DETECTION_METHOD_NONE);
+
+        Self {
+            partial_reliability,
+            message_interleaving,
+            reconfig,
+            zero_checksum_method,
+            negotiated_maximum_incoming_streams: nbr_outbound_streams,
+            negotiated_maximum_outgoing_streams: nbr_inbound_streams,
+        }
+    }
+
+    /// Negotiates the capabilities of the association.
+    ///
+    /// When this struct represents the capabilities supported by the peer, and the local socket
+    /// options are passed in, this returns the mutually supported and negotiated capabilities.
+    pub fn negotiate(&self, options: &Options) -> Capabilities {
+        let partial_reliability = options.enable_partial_reliability && self.partial_reliability;
+        let message_interleaving = options.enable_message_interleaving && self.message_interleaving;
+        let zero_checksum_method = if options.zero_checksum_alternate_error_detection_method
+            == self.zero_checksum_method
+        {
+            self.zero_checksum_method
+        } else {
+            ZERO_CHECKSUM_ALTERNATE_ERROR_DETECTION_METHOD_NONE
+        };
+
+        Capabilities {
+            partial_reliability,
+            message_interleaving,
+            reconfig: self.reconfig,
+            zero_checksum_method,
+            negotiated_maximum_incoming_streams: std::cmp::min(
+                options.announced_maximum_incoming_streams,
+                self.negotiated_maximum_incoming_streams,
+            ),
+            negotiated_maximum_outgoing_streams: std::cmp::min(
+                options.announced_maximum_outgoing_streams,
+                self.negotiated_maximum_outgoing_streams,
+            ),
+        }
+    }
+
+    /// Indicates if the RFC 9653 Zero Checksum is enabled.
+    pub fn zero_checksum_enabled(&self) -> bool {
+        self.zero_checksum_method != ZERO_CHECKSUM_ALTERNATE_ERROR_DETECTION_METHOD_NONE
+    }
 }

--- a/src/socket/connect.rs
+++ b/src/socket/connect.rs
@@ -59,8 +59,6 @@ use crate::types::Tsn;
 use log::info;
 #[cfg(not(test))]
 use log::warn;
-use std::cmp::min;
-use std::collections::HashSet;
 #[cfg(test)]
 use std::println as info;
 #[cfg(test)]
@@ -185,14 +183,16 @@ pub(crate) fn handle_init(state: &mut State, ctx: &mut Context, chunk: InitChunk
         }
     }
 
-    let capabilities = compute_capabilities(
-        &ctx.options,
+    let peer_capabilities = Capabilities::from_parameters(
         chunk.nbr_outbound_streams,
         chunk.nbr_inbound_streams,
         &chunk.parameters,
     );
-    let write_checksum = !capabilities.zero_checksum;
-    let mut parameters = make_capability_parameters(&ctx.options, capabilities.zero_checksum);
+    let capabilities = peer_capabilities.negotiate(&ctx.options);
+    let write_checksum = !capabilities.zero_checksum_enabled();
+    let mut parameters =
+        make_capability_parameters(&ctx.options, capabilities.zero_checksum_enabled());
+
     parameters.push(Parameter::StateCookie(StateCookieParameter {
         cookie: StateCookie {
             peer_tag: chunk.initiate_tag,
@@ -201,7 +201,7 @@ pub(crate) fn handle_init(state: &mut State, ctx: &mut Context, chunk: InitChunk
             my_initial_tsn,
             a_rwnd: chunk.a_rwnd,
             tie_tag,
-            capabilities,
+            peer_capabilities,
         }
         .serialize(),
     }));
@@ -395,7 +395,7 @@ pub(crate) fn handle_cookie_echo(
         unreachable!();
     };
 
-    let write_checksum = !tcb.capabilities.zero_checksum;
+    let write_checksum = !tcb.capabilities.zero_checksum_enabled();
     let mut b = SctpPacketBuilder::new(
         cookie.peer_tag,
         ctx.options.local_port,
@@ -474,13 +474,15 @@ fn establish_new_tcb(
     cookie: &StateCookie,
     reset_queue: bool,
 ) {
-    ctx.send_queue.enable_message_interleaving(cookie.capabilities.message_interleaving);
+    let capabilities = cookie.peer_capabilities.negotiate(&ctx.options);
+    ctx.send_queue.enable_message_interleaving(capabilities.message_interleaving);
 
     if reset_queue {
         ctx.send_queue.reset();
     }
 
     let tie_tag = fastrand::u64(..);
+    let a_rwnd = std::cmp::min(cookie.a_rwnd, ctx.options.max_send_buffer_size as u32);
     let new_tcb = TransmissionControlBlock::new(
         &ctx.options,
         cookie.my_tag,
@@ -488,8 +490,8 @@ fn establish_new_tcb(
         cookie.peer_tag,
         cookie.peer_initial_tsn,
         tie_tag,
-        cookie.a_rwnd,
-        cookie.capabilities,
+        a_rwnd,
+        capabilities,
         ctx.events.clone(),
     );
 
@@ -558,56 +560,8 @@ fn compute_capabilities(
     peer_nbr_inbound_streams: u16,
     parameters: &[Parameter],
 ) -> Capabilities {
-    let supported: HashSet<u8> = HashSet::from_iter(
-        parameters
-            .iter()
-            .find_map(|e| match e {
-                Parameter::SupportedExtensions(SupportedExtensionsParameter { chunk_types }) => {
-                    Some(chunk_types)
-                }
-                _ => None,
-            })
-            .unwrap_or(&vec![])
-            .iter()
-            .cloned()
-            .collect::<HashSet<_>>(),
-    );
-
-    let partial_reliability = options.enable_partial_reliability
-        && (parameters.iter().any(|e| matches!(e, Parameter::ForwardTsnSupported(_)))
-            || supported.contains(&forward_tsn_chunk::CHUNK_TYPE));
-
-    let message_interleaving = options.enable_message_interleaving
-        && supported.contains(&idata_chunk::CHUNK_TYPE)
-        && supported.contains(&iforward_tsn_chunk::CHUNK_TYPE);
-
-    let peer_zero_checksum = *parameters
-        .iter()
-        .find_map(|e| match e {
-            Parameter::ZeroChecksumAcceptable(ZeroChecksumAcceptableParameter { method }) => {
-                Some(method)
-            }
-            _ => None,
-        })
-        .unwrap_or(&ZERO_CHECKSUM_ALTERNATE_ERROR_DETECTION_METHOD_NONE);
-    let zero_checksum = (options.zero_checksum_alternate_error_detection_method
-        != ZERO_CHECKSUM_ALTERNATE_ERROR_DETECTION_METHOD_NONE)
-        && (options.zero_checksum_alternate_error_detection_method == peer_zero_checksum);
-
-    Capabilities {
-        partial_reliability,
-        message_interleaving,
-        reconfig: supported.contains(&re_config_chunk::CHUNK_TYPE),
-        zero_checksum,
-        negotiated_maximum_incoming_streams: min(
-            options.announced_maximum_incoming_streams,
-            peer_nbr_outbound_streams,
-        ),
-        negotiated_maximum_outgoing_streams: min(
-            options.announced_maximum_outgoing_streams,
-            peer_nbr_inbound_streams,
-        ),
-    }
+    Capabilities::from_parameters(peer_nbr_outbound_streams, peer_nbr_inbound_streams, parameters)
+        .negotiate(options)
 }
 
 fn make_capability_parameters(options: &Options, support_zero_checksum: bool) -> Vec<Parameter> {

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -29,6 +29,7 @@ use crate::api::SocketEvent;
 use crate::api::SocketState;
 use crate::api::SocketTime;
 use crate::api::StreamId;
+use crate::api::ZERO_CHECKSUM_ALTERNATE_ERROR_DETECTION_METHOD_NONE;
 use crate::api::handover::HandoverReadiness;
 use crate::api::handover::HandoverSocketState;
 use crate::api::handover::SocketHandoverState;
@@ -815,7 +816,7 @@ impl DcSctpSocket for Socket {
             peer_rwnd_bytes: tcb.retransmission_queue.rwnd() as u32,
             peer_implementation: self.ctx.peer_implementation,
             uses_message_interleaving: tcb.capabilities.message_interleaving,
-            uses_zero_checksum: tcb.capabilities.zero_checksum,
+            uses_zero_checksum: tcb.capabilities.zero_checksum_enabled(),
             negotiated_maximum_incoming_streams: tcb
                 .capabilities
                 .negotiated_maximum_incoming_streams,
@@ -849,7 +850,11 @@ impl DcSctpSocket for Socket {
             partial_reliability: state.capabilities.partial_reliability,
             message_interleaving: state.capabilities.message_interleaving,
             reconfig: state.capabilities.reconfig,
-            zero_checksum: state.capabilities.zero_checksum,
+            zero_checksum_method: if state.capabilities.zero_checksum {
+                self.ctx.options.zero_checksum_alternate_error_detection_method
+            } else {
+                ZERO_CHECKSUM_ALTERNATE_ERROR_DETECTION_METHOD_NONE
+            },
             negotiated_maximum_incoming_streams: state
                 .capabilities
                 .negotiated_maximum_incoming_streams,

--- a/src/socket/state_cookie.rs
+++ b/src/socket/state_cookie.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::api::ZeroChecksumAlternateErrorDetectionMethod;
 use crate::packet::read_u16_be;
 use crate::packet::read_u32_be;
 use crate::packet::read_u64_be;
@@ -21,7 +22,7 @@ use crate::packet::write_u64_be;
 use crate::socket::capabilities::Capabilities;
 use crate::types::Tsn;
 
-const COOKIE_SIZE: usize = 44;
+const COOKIE_SIZE: usize = 48;
 const MAGIC_1: u32 = 1684230979;
 const MAGIC_2: u32 = 1414558256;
 
@@ -32,7 +33,7 @@ pub struct StateCookie {
     pub my_initial_tsn: Tsn,
     pub a_rwnd: u32,
     pub tie_tag: u64,
-    pub capabilities: Capabilities,
+    pub peer_capabilities: Capabilities,
 }
 
 impl StateCookie {
@@ -47,20 +48,28 @@ impl StateCookie {
             return Err("Invalid state cookie magic");
         }
 
+        let peer_tag = read_u32_be!(&data[8..12]);
+        let my_tag = read_u32_be!(&data[12..16]);
+        if peer_tag == 0 || my_tag == 0 {
+            return Err("Invalid verification tag in state cookie");
+        }
+
         Ok(StateCookie {
-            peer_tag: read_u32_be!(&data[8..12]),
-            my_tag: read_u32_be!(&data[12..16]),
+            peer_tag,
+            my_tag,
             peer_initial_tsn: Tsn(read_u32_be!(&data[16..20])),
             my_initial_tsn: Tsn(read_u32_be!(&data[20..24])),
             a_rwnd: read_u32_be!(&data[24..28]),
             tie_tag: read_u64_be!(&data[28..36]),
-            capabilities: Capabilities {
+            peer_capabilities: Capabilities {
                 partial_reliability: data[36] != 0,
                 message_interleaving: data[37] != 0,
                 reconfig: data[38] != 0,
-                zero_checksum: data[39] != 0,
-                negotiated_maximum_incoming_streams: read_u16_be!(&data[40..42]),
-                negotiated_maximum_outgoing_streams: read_u16_be!(&data[42..44]),
+                zero_checksum_method: ZeroChecksumAlternateErrorDetectionMethod(read_u32_be!(
+                    &data[40..44]
+                )),
+                negotiated_maximum_incoming_streams: read_u16_be!(&data[44..46]),
+                negotiated_maximum_outgoing_streams: read_u16_be!(&data[46..48]),
             },
         })
     }
@@ -75,12 +84,20 @@ impl StateCookie {
         write_u32_be!(&mut data[20..24], self.my_initial_tsn.0);
         write_u32_be!(&mut data[24..28], self.a_rwnd);
         write_u64_be!(&mut data[28..36], self.tie_tag);
-        data[36] = self.capabilities.partial_reliability as u8;
-        data[37] = self.capabilities.message_interleaving as u8;
-        data[38] = self.capabilities.reconfig as u8;
-        data[39] = self.capabilities.zero_checksum as u8;
-        write_u16_be!(&mut data[40..42], self.capabilities.negotiated_maximum_incoming_streams);
-        write_u16_be!(&mut data[42..44], self.capabilities.negotiated_maximum_outgoing_streams);
+        data[36] = self.peer_capabilities.partial_reliability as u8;
+        data[37] = self.peer_capabilities.message_interleaving as u8;
+        data[38] = self.peer_capabilities.reconfig as u8;
+        data[39] = 0; // padding
+        write_u32_be!(&mut data[40..44], self.peer_capabilities.zero_checksum_method.0);
+        write_u16_be!(
+            &mut data[44..46],
+            self.peer_capabilities.negotiated_maximum_incoming_streams
+        );
+        write_u16_be!(
+            &mut data[46..48],
+            self.peer_capabilities.negotiated_maximum_outgoing_streams
+        );
+
         data
     }
 }
@@ -98,11 +115,11 @@ mod tests {
             my_initial_tsn: Tsn(654),
             a_rwnd: 789,
             tie_tag: 1020304050,
-            capabilities: Capabilities {
+            peer_capabilities: Capabilities {
                 partial_reliability: true,
                 message_interleaving: false,
                 reconfig: true,
-                zero_checksum: true,
+                zero_checksum_method: ZeroChecksumAlternateErrorDetectionMethod(1),
                 negotiated_maximum_incoming_streams: 123,
                 negotiated_maximum_outgoing_streams: 234,
             },
@@ -117,11 +134,14 @@ mod tests {
         assert_eq!(deserialized.my_initial_tsn, Tsn(654));
         assert_eq!(deserialized.a_rwnd, 789);
         assert_eq!(deserialized.tie_tag, 1020304050);
-        assert!(deserialized.capabilities.partial_reliability);
-        assert!(!deserialized.capabilities.message_interleaving);
-        assert!(deserialized.capabilities.reconfig);
-        assert!(deserialized.capabilities.zero_checksum);
-        assert_eq!(deserialized.capabilities.negotiated_maximum_incoming_streams, 123);
-        assert_eq!(deserialized.capabilities.negotiated_maximum_outgoing_streams, 234);
+        assert!(deserialized.peer_capabilities.partial_reliability);
+        assert!(!deserialized.peer_capabilities.message_interleaving);
+        assert!(deserialized.peer_capabilities.reconfig);
+        assert_eq!(
+            deserialized.peer_capabilities.zero_checksum_method,
+            ZeroChecksumAlternateErrorDetectionMethod(1)
+        );
+        assert_eq!(deserialized.peer_capabilities.negotiated_maximum_incoming_streams, 123);
+        assert_eq!(deserialized.peer_capabilities.negotiated_maximum_outgoing_streams, 234);
     }
 }

--- a/src/socket/transmission_control_block.rs
+++ b/src/socket/transmission_control_block.rs
@@ -220,7 +220,7 @@ impl TransmissionControlBlock {
             self.remote_port,
             self.max_packet_size,
         );
-        b.write_checksum(!self.capabilities.zero_checksum);
+        b.write_checksum(!self.capabilities.zero_checksum_enabled());
         b
     }
 
@@ -241,7 +241,7 @@ impl TransmissionControlBlock {
             partial_reliability: self.capabilities.partial_reliability,
             message_interleaving: self.capabilities.message_interleaving,
             reconfig: self.capabilities.reconfig,
-            zero_checksum: self.capabilities.zero_checksum,
+            zero_checksum: self.capabilities.zero_checksum_enabled(),
             negotiated_maximum_incoming_streams: self
                 .capabilities
                 .negotiated_maximum_incoming_streams,


### PR DESCRIPTION
This commit enhances the security and robustness of the state cookie by limiting what an attacker can achieve even if they manage to forge or  tamper with the cookie. Note that we don't add any signature or digest  right now, as that would be done by adding library dependencies that the downstream projects don't use right now (sha2 and hmac). This might be rivisited in the future.

By storing the raw peer capabilities in the state cookie, we prevent an  attacker from enabling extensions that the local socket didn't signal support for, limit the stream limits (incoming and outgoing) from what was originally announced, and also elimintate some duplication in  capability parsing in the different methods to do connection handshakes.

This defense-in-depth measure ensures that the state instantiated from a COOKIE ECHO strictly matches the parameters of the original INIT, and if an attacker tampers with it, the effects are very limited.